### PR TITLE
New methods and a fix for the GPS epoch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,16 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-rand = "0.8"
-rand_distr = "0.4"
-regex = "1.3"
-serde = "1.0"
-serde_derive = "1.0"
+rand = "0.8.0"
+rand_distr = "0.4.0"
+regex = "1.3.0"
+serde = "1.0.0"
+serde_derive = "1.0.0"
 twofloat = "0.4.1"
 
 [dev-dependencies]
-serde_derive = "1.0"
-criterion = "0.3"
+serde_derive = "1.0.0"
+criterion = "0.3.0"
 
 [[bench]]
 name = "bench_epoch"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,14 @@ pub const SECONDS_PER_YEAR: f64 = 31_557_600.0;
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
 /// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sideral year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
 pub const SECONDS_PER_SIDERAL_YEAR: f64 = 31_558_150.0;
+/// `SECONDS_GPS_TAI_OFFSET` is the number of seconds from the TAI epoch to the
+/// GPS epoch (UTC midnight of January 6th 1980; cf.
+/// https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29)
+pub const SECONDS_GPS_TAI_OFFSET: f64 = 80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
+/// `DAYS_GPS_TAI_OFFSET` is the number of days from the TAI epoch to the GPS
+/// epoch (UTC midnight of January 6th 1980; cf.
+/// https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29)
+pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
 
 mod sim;
 pub use sim::ClockNoise;


### PR DESCRIPTION
Hi!  Thanks very much for `hifitime`, it's been a lifesaver to deal with JDs, MJDs and leap seconds.  I've been using it for about 1.5 years now.

I've got a lot going on in this PR so if you'd prefer for me to break it up or you have any questions, please let me know.  I also don't 100% trust myself with getting everything correct so I'd appreciate some experienced eyes over the changes.

The first commit is simple enough - it just specifies patch versions for dependencies seeing as that's generally a good thing to do.  In the commit message I've linked the relevant Rust users forum post that set me off tidying up this kinda stuff all over the place.

The second commit adds a bunch of functions that seemed to simply be missing from the library previously (`from_utc_{seconds,days}`, `from_{mjd,jde}_utc` and `from_gpst_{seconds,days}`). I'm reasonably happy with them but I'm not certain that everything is correct.

The third commit is the most significant and if this PR is merged, a new release of `hifitime` should probably be `3.0.0` because it's a breaking change.  Basically, it puts the GPS epoch at 1980/1/5 rather than just 19 seconds after TAI.  This helps me a lot because I frequently use GPS time for work and I had to use a hack to get around this in the past.

Your time and help is much appreciated, thanks!