### PR TITLE
Fix #112

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifitime"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/MathSpec/time/"

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ ET and TDB should now be identical. However, hifitime uses the European Space Ag
 # Changelog
 
 ## 3.0.0
-+ Backend rewritten from TwoFloat to a struct of the centuries in `i16` and nanoseconds in `u64`. Thanks to @pwnorbitals for proposing the idea in #107 and writing the proof of concept. This leads to at least a 2x speed up in most calculations, cf. [this comment](https://github.com/nyx-space/hifitime/pull/107#issuecomment-1040702004).
-+ Fix GPS epoch, and addition of a helper functions in `Epoch` by @cjordan
++ Backend rewritten from TwoFloat to a struct of the centuries in `i16` and nanoseconds in `u64`. Thanks to [@pwnorbitals](https://github.com/pwnorbitals) for proposing the idea in #107 and writing the proof of concept. This leads to at least a 2x speed up in most calculations, cf. [this comment](https://github.com/nyx-space/hifitime/pull/107#issuecomment-1040702004).
++ Fix GPS epoch, and addition of a helper functions in `Epoch` by [@cjordan](https://github.com/cjordan)
 
 ## 2.2.3
 + More deterministic `as_jde_tdb_days()` in `Epoch`. In version 2.2.1, the ephemeris time and TDB _days_ were identical down to machine precision. After a number of validation cases in the rotation equations of the IAU Earth to Earth Mean Equator J2000 frame, the new formulation was shown to lead to less rounding errors when requesting the days. These rounding errors prevented otherwise trivial test cases. However, it adds an error of **40.2 nanoseconds** when initializing an Epoch with the days in ET and requesting the TDB days.

--- a/benches/bench_epoch.rs
+++ b/benches/bench_epoch.rs
@@ -3,6 +3,7 @@ extern crate hifitime;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hifitime::{Duration, Epoch, Unit};
 
+#[allow(unused_must_use)]
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("TBD seconds and JDE ET", |b| {
         b.iter(|| {

--- a/benches/bench_epoch.rs
+++ b/benches/bench_epoch.rs
@@ -16,6 +16,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("TT", |b| {
+        b.iter(|| {
+            // TT is too slow now! Used to be 184ns, is now 241
+            let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);
+            e.as_tt_seconds();
+
+            let f: Epoch = e + black_box(50) * Unit::Second;
+            f.as_tt_seconds();
+        })
+    });
+
     c.bench_function("Duration to f64 seconds", |b| {
         b.iter(|| {
             let d: Duration = Unit::Second * black_box(3.0);
@@ -37,7 +48,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("Duration add and assert subsecons", |b| {
+    c.bench_function("Duration add and assert subseconds", |b| {
         b.iter(|| {
             assert_eq!(
                 Unit::Millisecond * black_box(4.0),

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -214,9 +214,13 @@ impl Duration {
         // Compute the seconds and nanoseconds that we know this fits on a 64bit float
         let seconds = self.nanoseconds.div_euclid(NANOSECONDS_PER_SECOND);
         let subseconds = self.nanoseconds.rem_euclid(NANOSECONDS_PER_SECOND);
-        f64::from(self.centuries) * SECONDS_PER_CENTURY
-            + (seconds as f64)
-            + (subseconds as f64) * 1e-9
+        if self.centuries == 0 {
+            (seconds as f64) + (subseconds as f64) * 1e-9
+        } else {
+            f64::from(self.centuries) * SECONDS_PER_CENTURY
+                + (seconds as f64)
+                + (subseconds as f64) * 1e-9
+        }
     }
 
     /// Returns the value of this duration in the requested unit.

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -379,7 +379,6 @@ impl Mul<f64> for Duration {
                 break;
             }
             // Multiply by the precision
-            // Note: we multiply by powers of ten to avoid this kind of round error with f32s:
             // https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b760579f103b7192c20413ebbe167b90
             p += 1;
             new_val = q * ten.powi(p);
@@ -426,16 +425,6 @@ macro_rules! impl_ops_for_type {
                 q * self
             }
         }
-
-        // impl Mul<$type> for Duration {
-        //     type Output = Duration;
-        //     fn mul(self, q: $type) -> Self::Output {
-        //         Duration::from_total_nanoseconds(
-        //             self.total_nanoseconds()
-        //                 .saturating_mul((q * Unit::Nanosecond).total_nanoseconds()),
-        //         )
-        //     }
-        // }
 
         #[allow(clippy::suspicious_arithmetic_impl)]
         impl Div<$type> for Duration {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -727,6 +727,17 @@ impl Epoch {
         self.as_tdb_days_since_j2000() / DAYS_PER_CENTURY
     }
 
+    /// Returns the number of days since Ephemeris Time (ET) J2000 (used for Archinal et al. rotations)
+    pub fn as_et_days_since_j2000(self) -> f64 {
+        let jde_et_days = self.as_jde_et_days();
+        jde_et_days - MJD_OFFSET - J2000_OFFSET
+    }
+
+    /// Returns the number of centuries since Ephemeris Time (ET) J2000 (used for Archinal et al. rotations)
+    pub fn as_et_centuries_since_j2000(self) -> f64 {
+        self.as_et_days_since_j2000() / DAYS_PER_CENTURY
+    }
+
     /// Converts an ISO8601 Datetime representation without timezone offset to an Epoch.
     /// If no time system is specified, than UTC is assumed.
     /// The `T` which separates the date from the time can be replaced with a single whitespace character (`\W`).

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -83,9 +83,7 @@ impl Sub<Duration> for Epoch {
     type Output = Self;
 
     fn sub(self, duration: Duration) -> Self {
-        Self {
-            0: self.0 - duration,
-        }
+        Self(self.0 - duration)
     }
 }
 
@@ -95,9 +93,7 @@ impl Add<f64> for Epoch {
     /// WARNING: For speed, there is a possibility to add seconds directly to an Epoch.
     /// Using this is _discouraged_ and should only be used if you have facing bottlenecks with the units.
     fn add(self, seconds: f64) -> Self {
-        Self {
-            0: (self.0.in_seconds() + seconds) * Unit::Second,
-        }
+        Self((self.0.in_seconds() + seconds) * Unit::Second)
     }
 }
 
@@ -105,9 +101,7 @@ impl Add<Duration> for Epoch {
     type Output = Self;
 
     fn add(self, duration: Duration) -> Self {
-        Self {
-            0: self.0 + duration,
-        }
+        Self(self.0 + duration)
     }
 }
 
@@ -130,9 +124,7 @@ impl Sub<Unit> for Epoch {
 
     #[allow(clippy::identity_op)]
     fn sub(self, unit: Unit) -> Self {
-        Self {
-            0: self.0 - unit * 1,
-        }
+        Self(self.0 - unit * 1)
     }
 }
 
@@ -141,9 +133,7 @@ impl Add<Unit> for Epoch {
 
     #[allow(clippy::identity_op)]
     fn add(self, unit: Unit) -> Self {
-        Self {
-            0: self.0 + unit * 1,
-        }
+        Self(self.0 + unit * 1)
     }
 }
 
@@ -177,9 +167,7 @@ impl Epoch {
             seconds.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self {
-            0: seconds * Unit::Second,
-        }
+        Self(seconds * Unit::Second)
     }
 
     /// Initialize an Epoch from the provided TAI days since 1900 January 01 at midnight
@@ -188,9 +176,7 @@ impl Epoch {
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self {
-            0: days * Unit::Day,
-        }
+        Self(days * Unit::Day)
     }
 
     /// Initialize an Epoch from the provided UTC seconds since 1900 January 01
@@ -224,9 +210,7 @@ impl Epoch {
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self {
-            0: (days - J1900_OFFSET) * Unit::Day,
-        }
+        Self((days - J1900_OFFSET) * Unit::Day)
     }
 
     pub fn from_mjd_utc(days: f64) -> Self {
@@ -241,9 +225,7 @@ impl Epoch {
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self {
-            0: (days - J1900_OFFSET - MJD_OFFSET) * Unit::Day,
-        }
+        Self((days - J1900_OFFSET - MJD_OFFSET) * Unit::Day)
     }
 
     pub fn from_jde_utc(days: f64) -> Self {
@@ -292,9 +274,7 @@ impl Epoch {
         // Decimal does not provide trig functions, so let's define the parts of the trig separately.
         let inner = g_rad + 0.0167 * g_rad.sin();
 
-        Self {
-            0: tt_duration + ((ET_EPOCH_S as f64) - (0.001_658 * inner.sin())) * Unit::Second,
-        }
+        Self(tt_duration + ((ET_EPOCH_S as f64) - (0.001_658 * inner.sin())) * Unit::Second)
     }
 
     pub fn from_jde_et(days: f64) -> Self {
@@ -394,16 +374,11 @@ impl Epoch {
         }
 
         Ok(match ts {
-            TimeSystem::TAI => Self {
-                0: seconds_wrt_1900,
-            },
-            TimeSystem::TT => Self {
-                0: (seconds_wrt_1900 - Unit::Millisecond * TT_OFFSET_MS),
-            },
-            TimeSystem::ET => Self {
-                0: (seconds_wrt_1900 + Unit::Second * ET_EPOCH_S
-                    - Unit::Microsecond * ET_OFFSET_US),
-            },
+            TimeSystem::TAI => Self(seconds_wrt_1900),
+            TimeSystem::TT => Self(seconds_wrt_1900 - Unit::Millisecond * TT_OFFSET_MS),
+            TimeSystem::ET => Self(
+                seconds_wrt_1900 + Unit::Second * ET_EPOCH_S - Unit::Microsecond * ET_OFFSET_US,
+            ),
             TimeSystem::TDB => Self::from_tdb_seconds_d(seconds_wrt_1900),
             TimeSystem::UTC => panic!("use maybe_from_gregorian_utc for UTC time system"),
         })

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -728,7 +728,7 @@ impl Epoch {
 
     /// Returns the number of days since Dynamic Barycentric Time (TDB) J2000 (used for Archinal et al. rotations)
     pub fn as_tdb_days_since_j2000(self) -> f64 {
-        self.as_tdb_duration_since_j2000().in_seconds()
+        self.as_tdb_duration_since_j2000().in_unit(Unit::Day)
     }
 
     /// Returns the number of centuries since Dynamic Barycentric Time (TDB) J2000 (used for Archinal et al. rotations)
@@ -743,7 +743,7 @@ impl Epoch {
 
     /// Returns the number of days since Ephemeris Time (ET) J2000 (used for Archinal et al. rotations)
     pub fn as_et_days_since_j2000(self) -> f64 {
-        self.as_et_duration_since_j2000().in_seconds()
+        self.as_et_duration_since_j2000().in_unit(Unit::Day)
     }
 
     /// Returns the number of centuries since Ephemeris Time (ET) J2000 (used for Archinal et al. rotations)
@@ -1563,8 +1563,8 @@ fn spice_et_tdb() {
 
     // 2012-02-07T11:22:00.818924427 TAI
     let sp_ex = Epoch::from_et_seconds(381_885_753.003_859_5);
-    assert!(dbg!(2455964.9739931 - sp_ex.as_jde_tdb_days()).abs() < 4.7e-10);
-    assert!(dbg!(2455964.9739931 - sp_ex.as_jde_et_days()).abs() < std::f64::EPSILON);
+    assert!(dbg!(2455964.9739931 - sp_ex.as_jde_et_days()).abs() < 4.7e-10);
+    assert!(dbg!(2455964.9739931 - sp_ex.as_jde_tdb_days()).abs() < std::f64::EPSILON);
 
     let sp_ex = Epoch::from_et_seconds(0.0);
     assert!(sp_ex.as_et_seconds() < std::f64::EPSILON);
@@ -1727,13 +1727,19 @@ fn et_init() {
 }
 
 #[test]
-fn e2022() {
-    let et0 = Epoch::from_gregorian_utc_at_noon(2022, 11, 30);
-    println!("{}", et0);
-    println!("{:x}", et0);
-    println!("{}", et0.as_jde_et_duration());
-    println!("{}", et0.as_jde_tdb_duration());
-    println!("{}", et0.as_jde_tdb_duration() - et0.as_jde_et_duration());
-    println!("{}", et0.as_jde_et_days());
-    println!("{}", et0.as_jde_tdb_days());
+fn test_days_tdb_j2000() {
+    let e = Epoch(Duration::from_parts(1, 723038437000000000));
+    let days_d = e.as_tdb_days_since_j2000();
+    let centuries_t = e.as_tdb_centuries_since_j2000();
+    assert!((days_d - 8369.000800729867).abs() < f64::EPSILON);
+    assert!((centuries_t - 0.22913075429787455).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_const_ops() {
+    // Tests that multiplying a constant with a unit returns the correct number in that same unit
+    let mjd_offset = MJD_OFFSET * Unit::Day;
+    assert!((mjd_offset.in_unit(Unit::Day) - MJD_OFFSET).abs() < f64::EPSILON);
+    let j2000_offset = J2000_OFFSET * Unit::Day;
+    assert!((j2000_offset.in_unit(Unit::Day) - J2000_OFFSET).abs() < f64::EPSILON);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub const J1900_OFFSET: f64 = 15_020.0;
 /// Modified Julian Day at 17 November 1858.
 pub const J2000_OFFSET: f64 = 51_544.5;
 /// The Ephemeris Time epoch, in seconds
-pub const ET_EPOCH_S: f64 = 3_155_716_800.0;
+pub const ET_EPOCH_S: i64 = 3_155_716_800;
 /// Modified Julian Date in seconds as defined [here](http://tycho.usno.navy.mil/mjd.html). MJD epoch is Modified Julian Day at 17 November 1858 at midnight.
 pub const MJD_OFFSET: f64 = 2_400_000.5;
 /// The JDE offset in days
@@ -148,16 +148,19 @@ pub const JDE_OFFSET_SECONDS: f64 = JDE_OFFSET_DAYS * SECONDS_PER_DAY;
 pub const DAYS_PER_YEAR: f64 = 365.25;
 /// `DAYS_PER_CENTURY` corresponds to the number of days per centuy in the Julian calendar.
 pub const DAYS_PER_CENTURY: f64 = 36525.0;
+pub const DAYS_PER_CENTURY_I64: i64 = 36525;
 /// `SECONDS_PER_MINUTE` defines the number of seconds per minute.
 pub const SECONDS_PER_MINUTE: f64 = 60.0;
 /// `SECONDS_PER_HOUR` defines the number of seconds per hour.
 pub const SECONDS_PER_HOUR: f64 = 3_600.0;
 /// `SECONDS_PER_DAY` defines the number of seconds per day.
 pub const SECONDS_PER_DAY: f64 = 86_400.0;
+pub const SECONDS_PER_DAY_I64: i64 = 86_400;
 /// `SECONDS_PER_CENTURY` defines the number of seconds per century.
 pub const SECONDS_PER_CENTURY: f64 = SECONDS_PER_DAY * DAYS_PER_CENTURY;
 /// `SECONDS_PER_YEAR` corresponds to the number of seconds per julian year from [NAIF SPICE](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/jyear_c.html).
 pub const SECONDS_PER_YEAR: f64 = 31_557_600.0;
+pub const SECONDS_PER_YEAR_I64: i64 = 31_557_600;
 /// `SECONDS_PER_TROPICAL_YEAR` corresponds to the number of seconds per tropical year from [NAIF SPICE](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/tyear_c.html).
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
 /// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sideral year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
@@ -166,6 +169,8 @@ pub const SECONDS_PER_SIDERAL_YEAR: f64 = 31_558_150.0;
 /// GPS epoch (UTC midnight of January 6th 1980; cf.
 /// https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29)
 pub const SECONDS_GPS_TAI_OFFSET: f64 = 80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
+pub const SECONDS_GPS_TAI_OFFSET_I64: i64 =
+    80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
 /// `DAYS_GPS_TAI_OFFSET` is the number of days from the TAI epoch to the GPS
 /// epoch (UTC midnight of January 6th 1980; cf.
 /// https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29)


### PR DESCRIPTION
[WIP]


+ The multiplication of a TimeUnit with an i64 or f64 is now different depending on the type. This allows us to not round to zero when multiplying with a positive value that's less than one.
+ Lots of constants have been converted to i64 from f64: Duration is much more precise with integers because we don't suffer from the rounding of larger numbers

Latest benchmark
```
TBD seconds and JDE ET  time:   [394.01 ns 396.40 ns 399.39 ns]                                   
                        change: [-6.6733% -5.0128% -3.4732%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

TT                      time:   [241.91 ns 242.98 ns 244.17 ns]               
                        change: [-3.6562% -2.8098% -2.0224%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Duration to f64 seconds time:   [5.7174 ns 5.7520 ns 5.7903 ns]                                     
                        change: [-16.848% -14.331% -11.957%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

Duration add and assert day hour                                                                             
                        time:   [15.941 ns 16.016 ns 16.088 ns]
                        change: [-11.589% -10.095% -8.7021%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Duration add and assert minute second                                                                             
                        time:   [15.575 ns 15.625 ns 15.681 ns]
                        change: [-17.673% -15.797% -14.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

Duration add and assert subseconds                                                                             
                        time:   [14.056 ns 14.128 ns 14.209 ns]
                        change: [-8.5139% -7.5222% -6.5690%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

```

Signed-off-by: Christopher Rabotin <christopher.rabotin@gmail.com>