### PR TITLE
Initialize from system time and add `ceil`, `floor`, and `round` to durations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifitime"
-version = "3.2.0-beta"
+version = "3.2.0"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/MathSpec/time/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
+libm = "0.2.2"
 serde = {version = "1.0.137", optional = true}
 regex = {version = "1.5.5", optional = true}
 serde_derive = {version = "1.0.137", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-serde = "1.0.137"
+serde = {version = "1.0.137", optional = true}
 regex = {version = "1.5.5", optional = true}
 serde_derive = {version = "1.0.137", optional = true}
 
@@ -21,7 +21,7 @@ criterion = "0.3.5"
 
 [features]
 default = ["std"]
-std = ["regex", "serde_derive"]
+std = ["regex", "serde", "serde_derive"]
 
 [[bench]]
 name = "bench_epoch"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ ET and TDB should now be identical. However, hifitime uses the European Space Ag
 # Changelog
 
 ## 3.2.0
++ Fix no-std implementation by using `libm` for non-core f64 operations
 + Add UNIX timestamp, thanks [@mkolopanis](https://github.com/mkolopanis)
 + Enums now derive `Eq` and some derive `Ord` (where relevant) #[118](https://github.com/nyx-space/hifitime/issues/118)
 + Use const fn where possible and switch to references where possible [#119](https://github.com/nyx-space/hifitime/issues/119)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ ET and TDB should now be identical. However, hifitime uses the European Space Ag
 + Add UNIX timestamp, thanks [@mkolopanis](https://github.com/mkolopanis)
 + Enums now derive `Eq` and some derive `Ord` (where relevant) #[118](https://github.com/nyx-space/hifitime/issues/118)
 + Use const fn where possible and switch to references where possible [#119](https://github.com/nyx-space/hifitime/issues/119)
-+ Allow extracting the centuries and nanoseconds of a Duration and Epoch, respectively with to_parts and to_tai_parts [#122](https://github.com/nyx-space/hifitime/issues/122)
++ Allow extracting the centuries and nanoseconds of a `Duration` and `Epoch`, respectively with to_parts and to_tai_parts [#122](https://github.com/nyx-space/hifitime/issues/122)
++ Add `ceil`, `floor`, `round` operations to `Epoch` and `Duration`
 ## 3.1.0
 + Add `#![no_std]` support
 + Add `to_parts` to `Duration` to extract the centuries and nanoseconds of a duration

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Scientifically accurate date and time handling with guaranteed nanosecond precis
 
 # Features
 
+ * [x] Initialize a high precision Epoch from the system time in UTC
  * [x] Leap seconds (as announced by the IETF on a yearly basis)
  * [x] UTC representation with ISO8601 formatting
  * [x] Trivial support of time arithmetic (e.g. `2.hours() + 3.seconds()`)
@@ -49,6 +50,13 @@ extern crate hifitime;
 ### Time creation
 ```rust
 use hifitime::{Epoch, Unit, TimeUnits};
+
+#[cfg(feature = "std")]
+{
+// Initialization from system time is only availble when std feature is enabled
+let now = Epoch::now().unwrap();
+println!("{}", now);
+}
 
 let mut santa = Epoch::from_gregorian_utc_hms(2017, 12, 25, 01, 02, 14);
 assert_eq!(santa.as_mjd_utc_days(), 58112.043217592590);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Scientifically accurate date and time handling with guaranteed nanosecond precis
  * [x] Initialize a high precision Epoch from the system time in UTC
  * [x] Leap seconds (as announced by the IETF on a yearly basis)
  * [x] UTC representation with ISO8601 formatting
- * [x] Trivial support of time arithmetic (e.g. `2.hours() + 3.seconds()`)
+ * [x] Trivial support of time arithmetic: addition (e.g. `2.hours() + 3.seconds()`), subtraction (e.g. `2.hours() - 3.seconds()`), round/floor/ceil operations (e.g. `2.hours().round(3.seconds())`)
  * [x] Supports ranges of Epochs and TimeSeries (linspace of `Epoch`s and `Duration`s)
  * [x] Trivial conversion between the time systems TAI, TT, ET, TDB, GPS, and UNIX.
  * [x] High fidelity Ephemeris Time / Dynamic Barycentric Time (TDB) computations from [ESA's Navipedia](https://gssc.esa.int/navipedia/index.php/Transformations_between_Time_Systems#TDT_-_TDB.2C_TCB)

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1265,7 +1265,7 @@ mod tests {
     }
 
     #[test]
-    fn duration_floor_ceil() {
+    fn duration_floor_ceil_round() {
         // These are from here: https://www.geeksforgeeks.org/time-round-function-in-golang-with-examples/
         let d = 5.minutes() + 7.seconds();
         assert_eq!(d.floor(6.seconds()), 5.minutes() + 6.seconds());

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1013,6 +1013,54 @@ impl Epoch {
             nanos,
         )
     }
+
+    /// Floors this epoch to the closest provided duration
+    ///
+    /// # Example
+    /// ```
+    /// use hifitime::{Epoch, TimeUnits};
+    ///
+    /// let e = Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 57, 43);
+    /// assert_eq!(
+    ///     e.floor(1.hours()),
+    ///     Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 0, 0)
+    /// );
+    /// ```
+    pub fn floor(&self, duration: Duration) -> Self {
+        Self(self.0.floor(duration))
+    }
+
+    /// Ceils this epoch to the closest provided duration
+    ///
+    /// # Example
+    /// ```
+    /// use hifitime::{Epoch, TimeUnits};
+    ///
+    /// let e = Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 57, 43);
+    /// assert_eq!(
+    ///     e.ceil(1.hours()),
+    ///     Epoch::from_gregorian_tai_hms(2022, 5, 20, 18, 0, 0)
+    /// );
+    /// ```
+    pub fn ceil(&self, duration: Duration) -> Self {
+        Self(self.0.ceil(duration))
+    }
+
+    /// Rounds this epoch to the closest provided duration
+    ///
+    /// # Example
+    /// ```
+    /// use hifitime::{Epoch, TimeUnits};
+    ///
+    /// let e = Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 57, 43);
+    /// assert_eq!(
+    ///     e.round(1.hours()),
+    ///     Epoch::from_gregorian_tai_hms(2022, 5, 20, 18, 0, 0)
+    /// );
+    /// ```
+    pub fn round(&self, duration: Duration) -> Self {
+        Self(self.0.round(duration))
+    }
 }
 
 #[cfg(feature = "std")]
@@ -2032,5 +2080,25 @@ mod tests {
         // Simply ensure that this call does not panic
         let now = Epoch::now().unwrap();
         println!("{now}");
+    }
+
+    #[test]
+    fn test_floor_ceil_round() {
+        // NOTE: This test suite is more limited than the Duration equivalent because Epoch uses Durations for these operations.
+        use crate::TimeUnits;
+
+        let e = Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 57, 43);
+        assert_eq!(
+            e.ceil(1.hours()),
+            Epoch::from_gregorian_tai_hms(2022, 5, 20, 18, 0, 0)
+        );
+        assert_eq!(
+            e.floor(1.hours()),
+            Epoch::from_gregorian_tai_hms(2022, 5, 20, 17, 0, 0)
+        );
+        assert_eq!(
+            e.round(1.hours()),
+            Epoch::from_gregorian_tai_hms(2022, 5, 20, 18, 0, 0)
+        );
     }
 }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1,3 +1,5 @@
+use libm::{fabs, sin, trunc};
+
 use crate::duration::{Duration, Unit};
 use crate::{
     Errors, TimeSystem, DAYS_GPS_TAI_OFFSET, ET_EPOCH_S, J1900_OFFSET, J2000_OFFSET, MJD_OFFSET,
@@ -301,9 +303,9 @@ impl Epoch {
         let g_rad = (PI / 180.0) * (357.528 + 35_999.050 * tt_centuries_j2k);
 
         // Decimal does not provide trig functions, so let's define the parts of the trig separately.
-        let inner = g_rad + 0.0167 * g_rad.sin();
+        let inner = g_rad + 0.0167 * sin(g_rad);
 
-        Self(tt_duration + ((ET_EPOCH_S as f64) - (0.001_658 * inner.sin())) * Unit::Second)
+        Self(tt_duration + ((ET_EPOCH_S as f64) - (0.001_658 * sin(inner))) * Unit::Second)
     }
 
     #[must_use]
@@ -813,7 +815,7 @@ impl Epoch {
         let inner = self.inner_g_rad();
 
         self.as_tt_duration() - (ET_EPOCH_S * Unit::Second)
-            + (0.001_658 * inner.sin()) * Unit::Second
+            + (0.001_658 * sin(inner)) * Unit::Second
     }
 
     #[must_use]
@@ -821,7 +823,7 @@ impl Epoch {
     pub fn as_tdb_seconds(&self) -> f64 {
         // Note that we redo the calculation of as_tdb_duration to save computational cost
         let inner = self.inner_g_rad();
-        self.as_tt_seconds() - (ET_EPOCH_S as f64) + (0.001_658 * inner.sin())
+        self.as_tt_seconds() - (ET_EPOCH_S as f64) + (0.001_658 * sin(inner))
     }
 
     /// For TDB computation, we're using f64 only because BigDecimal is far too slow for Nyx (uses FromStr).
@@ -829,7 +831,7 @@ impl Epoch {
         use core::f64::consts::PI;
         let g_rad = (PI / 180.0) * (357.528 + 35_999.050 * self.as_tt_centuries_j2k());
 
-        g_rad + 0.0167 * g_rad.sin()
+        g_rad + 0.0167 * sin(g_rad)
     }
 
     #[must_use]
@@ -851,7 +853,7 @@ impl Epoch {
     #[must_use]
     pub fn as_jde_tdb_duration(&self) -> Duration {
         let inner = self.inner_g_rad();
-        let tdb_delta = (0.001_658 * inner.sin()) * Unit::Second;
+        let tdb_delta = (0.001_658 * sin(inner)) * Unit::Second;
         self.as_jde_tt_duration() + tdb_delta
     }
 
@@ -1373,7 +1375,24 @@ fn is_leap_year(year: i32) -> bool {
 }
 
 fn div_rem_f64(me: f64, rhs: f64) -> (i32, f64) {
-    ((me.div_euclid(rhs) as i32), me.rem_euclid(rhs))
+    ((div_euclid_f64(me, rhs) as i32), rem_euclid_f64(me, rhs))
+}
+
+fn div_euclid_f64(lhs: f64, rhs: f64) -> f64 {
+    let q = trunc(lhs / rhs);
+    if lhs % rhs < 0.0 {
+        return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+    }
+    q
+}
+
+fn rem_euclid_f64(lhs: f64, rhs: f64) -> f64 {
+    let r = lhs % rhs;
+    if r < 0.0 {
+        r + fabs(rhs)
+    } else {
+        r
+    }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,10 @@ pub enum Errors {
     ParseError(ParsingErrors),
     /// Raised when trying to initialize an Epoch or Duration from its hi and lo values, but these overlap
     ConversionOverlapError(f64, f64),
+    /// Raised if an overflow occured
     Overflow,
+    /// Raised if the initialization from system time failed
+    SystemTimeError,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -125,6 +128,7 @@ impl fmt::Display for Errors {
                 f,
                 "overflow occured when trying to convert Duration information"
             ),
+            Self::SystemTimeError => write!(f, "std::time::SystemTime returned an error"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ pub mod prelude {
     pub use {Duration, Epoch, Freq, Frequencies, TimeSeries, TimeUnits, Unit};
 }
 
+extern crate libm;
+
+#[cfg(feature = "std")]
 extern crate serde;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
TODO:
- [x] Add ceil, floor, and round to `Epoch` (currently only on `Duration`).
- [x] Add libm when no default features (removing serde from default features actually seems to have broken things)
- [x] Also fix no-std support! I didn't realize that was broken.