### PR TITLE
Fix num-traits usage for no-std

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 
-name: Test Workflow
+name: Formal Verification Workflow
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,10 +45,28 @@ jobs:
       
       - name: Test (no default features)
         run: cargo test --no-default-features
-      
+
       - name: Test (asn1der)
         run: cargo test --features asn1der
 
+  test_no_std:
+    name: no-std Nightly Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rust-src
+
+      - name: Build (nightly + no default features + no_std target)
+        run: cargo build --no-default-features --target=aarch64-unknown-none -Z build-std=core
+      
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo test --features asn1der
 
   test_no_std:
-    name: no-std Nightly Test Suite
+    name: no-std build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hifitime"
 version = "3.4.0"
+resolver = "2"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/MathSpec/time/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ der = {version = "0.6.0", features = ["derive", "real"], optional = true}
 [dependencies.num-traits]
 version = "0.2"
 default-features = false
+features = ["libm"]
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -29,6 +29,9 @@ use super::serde::{de, Deserialize, Deserializer};
 #[cfg(feature = "std")]
 use std::str::FromStr;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 pub const DAYS_PER_CENTURY_U64: u64 = 36_525;
 pub const NANOSECONDS_PER_MICROSECOND: u64 = 1_000;
 pub const NANOSECONDS_PER_MILLISECOND: u64 = 1_000 * NANOSECONDS_PER_MICROSECOND;

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -29,6 +29,9 @@ use std::str::FromStr;
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 const TT_OFFSET_MS: i64 = 32_184;
 const ET_OFFSET_US: i64 = 32_184_935;
 

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -9,6 +9,9 @@
  */
 
 use super::{Duration, Epoch};
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /*
 
 NOTE: This is taken from itertools: https://docs.rs/itertools-num/0.1.3/src/itertools_num/linspace.rs.html#78-93 .


### PR DESCRIPTION
When attempting to compile for a target: aarch64-unknown-none I was failing due to a couple reasons.
They both go back to there is no-std library reference available for that architecture.
Compiling with "no_std" on my linux target works fine.

If you attempt a build with cargo such as:

```
cargo build --no-default-features --target=aarch64-unknown-none -Z build-std=core
```
The current hifitime/master was failing.

Thought I'd pass along my current patches.
Feel free to edit, change, or disregard.

### Feature resolver issues

I believe this goes back to the resolver dependency as shown in:
- https://github.com/rust-num/num-traits/issues/138

Added resolver="2" to the cargo.toml to fix this.

Another option would be to upgrade to the "edition = 2021" in cargo.toml.
The 2021 edition defaults to the new resolver.

### no-std and various float math functions

Also, in order to use the `sin()` and some other functions, I needed to add back the `libm` num-traits dependency.
Those functions do not exist in the current core.

Maybe at some point in the future the [core intrinsics sinf64()](https://doc.rust-lang.org/core/intrinsics/fn.sinf64.html) related functions will be stabilized.
