### PR TITLE
Fix formatting of Epochs

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: stable
           override: true
 
       - name: Install Kani

--- a/examples/python/timescales.py
+++ b/examples/python/timescales.py
@@ -34,13 +34,14 @@ if __name__ == "__main__":
     # Define the storage array
     data = []
     # Define the columns
-    columns = ["UTC Epoch", "Δ TT (s)", "Δ ET (s)", "Δ TDB (s)", "Δ UTC (s)"]
+    columns = ["UTC Epoch", "Δ TT (s)", "Δ ET (s)", "Δ TDB (s)", "Δ UTC (s)", "ET-TDB (s)"]
 
     for epoch in ts:
         delta_utc = epoch.as_utc_duration() - epoch.as_tai_duration()
         delta_tt = epoch.as_tt_duration() - epoch.as_tai_duration()
         delta_tdb = epoch.as_tdb_duration_since_j1900() - epoch.as_tai_duration()
         delta_et = epoch.as_et_duration_since_j1900() - epoch.as_tai_duration()
+        delta_et_tdb = delta_et - delta_tdb
         # Convert the epoch into a pandas datetime
         pd_epoch = pd.to_datetime(str(epoch))
         # Build the pandas series
@@ -49,15 +50,29 @@ if __name__ == "__main__":
             delta_tt.in_seconds(),
             delta_et.in_seconds(),
             delta_tdb.in_seconds(),
-            delta_utc.in_seconds()
+            delta_utc.in_seconds(),
+            delta_et_tdb.in_seconds(),
         ])
 
     df = pd.DataFrame(data, columns=columns)
 
-    fig = px.line(df, x='UTC Epoch', y=columns[1:], title="Time scale deviation (incl. UTC)")
+    fig = px.line(df,
+                  x='UTC Epoch',
+                  y=columns[1:-1],
+                  title="Time scale deviation with respect to TAI")
     fig.write_html("./target/time-scale-deviation.html")
     fig.show()
 
-    fig = px.line(df, x='UTC Epoch', y=columns[1:-1], title="Time scale deviation (excl. UTC)")
+    fig = px.line(df,
+                  x='UTC Epoch',
+                  y=columns[1:-2],
+                  title="Time scale deviation with respect to TAI (excl. UTC)")
     fig.write_html("./target/time-scale-deviation-no-utc.html")
+    fig.show()
+
+    fig = px.line(df,
+                  x='UTC Epoch',
+                  y=columns[-1],
+                  title="Time scale deviation of TDB and ET with respect to TAI")
+    fig.write_html("./target/time-scale-deviation-tdb-et.html")
     fig.show()

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -534,6 +534,11 @@ impl Duration {
         }
     }
 
+    /// Returns whether this is a negative or positive duration.
+    pub const fn is_negative(&self) -> bool {
+        self.centuries.is_negative()
+    }
+
     /// A duration of exactly zero nanoseconds
     pub const ZERO: Self = Self {
         centuries: 0,

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -427,3 +427,33 @@ fn std_time_duration() {
     let hf_return: Duration = std_duration.into();
     assert_eq!(hf_return, hf_duration);
 }
+
+#[test]
+fn test_decompose() {
+    let pos = 5 * Unit::Hour + 256 * Unit::Millisecond + Unit::Nanosecond;
+
+    let (sign, days, hours, minutes, seconds, milliseconds, microseconds, nanos) = pos.decompose();
+    assert_eq!(sign, 0);
+    assert_eq!(days, 0);
+    assert_eq!(hours, 5);
+    assert_eq!(minutes, 0);
+    assert_eq!(seconds, 0);
+    assert_eq!(milliseconds, 256);
+    assert_eq!(microseconds, 0);
+    assert_eq!(nanos, 1);
+
+    // A negative duration works in the same way, only the sign is different.
+    let neg = -(5 * Unit::Hour + 256 * Unit::Millisecond + Unit::Nanosecond);
+    assert_eq!(neg, -pos);
+    assert_eq!(neg.abs(), pos);
+
+    let (sign, days, hours, minutes, seconds, milliseconds, microseconds, nanos) = neg.decompose();
+    assert_eq!(sign, -1);
+    assert_eq!(days, 0);
+    assert_eq!(hours, 5);
+    assert_eq!(minutes, 0);
+    assert_eq!(seconds, 0);
+    assert_eq!(milliseconds, 256);
+    assert_eq!(microseconds, 0);
+    assert_eq!(nanos, 1);
+}

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -868,7 +868,6 @@ fn test_format() {
     // Try with epochs near 1900, reference of TAI
     let epoch_post = Epoch::from_gregorian_tai_hms(1900, 1, 1, 0, 0, 1);
     let epoch_pre = Epoch::from_gregorian_tai_hms(1899, 12, 31, 23, 59, 59);
-    println!("{}", epoch_post - epoch_pre);
 
     assert_eq!(epoch_post.duration_since_j1900_tai.decompose().0, 0);
     assert_eq!(epoch_pre.duration_since_j1900_tai.decompose().0, -1);

--- a/tests/timeseries.rs
+++ b/tests/timeseries.rs
@@ -1,6 +1,6 @@
 extern crate hifitime;
 
-use hifitime::{Epoch, TimeSeries, Unit};
+use hifitime::{Epoch, TimeSeries, TimeUnits, Unit};
 
 #[test]
 fn test_timeseries() {
@@ -72,4 +72,22 @@ fn gh131_regression() {
     let times = TimeSeries::inclusive(start, end, step);
     assert_eq!(times.len(), steps as usize);
     assert_eq!(times.len(), times.size_hint().0);
+}
+
+#[test]
+fn gh154_reciprocity() {
+    use core::str::FromStr;
+
+    // TODO: Reproduce for all time scales
+    for epoch in TimeSeries::inclusive(
+        Epoch::from_str("1970-03-02T00:00:00 UTC").unwrap(),
+        Epoch::from_str("2023-01-01 00:00:00 UTC").unwrap(),
+        30.days(),
+    ) {
+        #[cfg(feature = "std")]
+        println!("{epoch:x}");
+        let formatted = format!("{epoch:x}");
+        let rebuilt = Epoch::from_str(&formatted).unwrap();
+        assert_eq!(rebuilt, epoch, "got: {rebuilt:x}\nexp: {epoch:x}");
+    }
 }


### PR DESCRIPTION
The biggest pain here was correctly formatting and parsing epochs before 1900 TAI because one has to count the duration within one day backward in order to correctly format it.

The tests now ensure that whatever is printed with hifitime can also be read with `from_str`.