### PR TITLE
optimise gregorian

### DIFF
--- a/benches/bench_epoch.rs
+++ b/benches/bench_epoch.rs
@@ -17,7 +17,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("TT", |b| {
         b.iter(|| {
-            // TT is too slow now! Used to be 184ns, is now 241
             let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);
             e.as_tt_seconds();
 


### PR DESCRIPTION
The loops that were originally there didn't optimise well. This new code optimises much better with less branches

![Screenshot 2022-10-16 at 11 01 36](https://user-images.githubusercontent.com/6625462/196029380-bbecaa74-4a12-4d09-8f44-b387f5b55f02.png)

The one regression is a false positive and on re-runs switched between + and -