### PR TITLE
Remove redundant tests

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1139,26 +1139,7 @@ fn deser_test() {
 
 #[cfg(kani)]
 #[kani::proof]
-fn formal_normalize_min() {
-    // Test that a normalization from the min does not fail
-    let centuries = i16::MIN;
-    let nanoseconds: u64 = kani::any();
-    let _dur = Duration::from_parts(centuries, nanoseconds);
-}
-
-#[cfg(kani)]
-#[kani::proof]
-fn formal_normalize_max() {
-    // Test that a normalization from the min does not fail
-    let centuries = i16::MAX;
-    let nanoseconds: u64 = kani::any();
-    let _dur = Duration::from_parts(centuries, nanoseconds);
-}
-
-#[cfg(kani)]
-#[kani::proof]
 fn formal_normalize_any() {
-    // Test that a normalization from the min does not fail
     let centuries: i16 = kani::any();
     let nanoseconds: u64 = kani::any();
     let _dur = Duration::from_parts(centuries, nanoseconds);


### PR DESCRIPTION
Kani `any` is a symbolic value meaning all valid states will be solved for. See here: https://model-checking.github.io/kani/tool-comparison.html?highlight=exhau#comparison-with-other-tools