### PR TITLE
Usability enhancements, especially for Python

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install Kani
         run: |
+          sudo apt install python3-testresources
           cargo install --locked kani-verifier
           cargo-kani setup
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ In order to provide full interoperability with NAIF, hifitime uses the NAIF algo
 
 # Changelog
 
+## 3.5.1
++ Significant speed improvement in the initialization of Epochs from their Gregorian representation, thanks [@conradludgate](https://github.com/conradludgate) for [#160](https://github.com/nyx-space/hifitime/pull/160).
++ Epoch and Duration now have a `min` and `max` function which respectively returns a copy of the epoch/duration that is the smallest or the largest between `self` and `other`, cf. [#164](https://github.com/nyx-space/hifitime/issues/164).
++ [Python] Duration and Epochs now support the operators `>`, `>=`, `<`, `<=`, `==`, and `!=`. Epoch now supports `init_from_gregorian` with a time scape, like in Rust. Epochs can also be subtracted from one another using the `timedelta` function, cf. [#162](https://github.com/nyx-space/hifitime/issues/162).
+
 ## 3.5.0
 + Epoch now store the time scale that they were defined in: this allows durations to be added in their respective time scales. For example, adding 36 hours to 1971-12-31 at noon when the Epoch is initialized in UTC will lead to a different epoch than adding that same duration to an epoch initialized at the same time in TAI (because the first leap second announced by IERS was on 1972-01-01), cf. the `test_add_durations_over_leap_seconds` test.
 + RFC3339 and ISO8601 fully supported for initialization of an Epoch, including the offset, e.g. `Epoch::from_str("1994-11-05T08:15:30-05:00")`, cf. [#73](https://github.com/nyx-space/hifitime/issues/73).

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ In order to provide full interoperability with NAIF, hifitime uses the NAIF algo
 + Significant speed improvement in the initialization of Epochs from their Gregorian representation, thanks [@conradludgate](https://github.com/conradludgate) for [#160](https://github.com/nyx-space/hifitime/pull/160).
 + Epoch and Duration now have a `min` and `max` function which respectively returns a copy of the epoch/duration that is the smallest or the largest between `self` and `other`, cf. [#164](https://github.com/nyx-space/hifitime/issues/164).
 + [Python] Duration and Epochs now support the operators `>`, `>=`, `<`, `<=`, `==`, and `!=`. Epoch now supports `init_from_gregorian` with a time scape, like in Rust. Epochs can also be subtracted from one another using the `timedelta` function, cf. [#162](https://github.com/nyx-space/hifitime/issues/162).
++ TimeSeries can now be formatted in different time scales, cf. [#163](https://github.com/nyx-space/hifitime/issues/163)
 
 ## 3.5.0
 + Epoch now store the time scale that they were defined in: this allows durations to be added in their respective time scales. For example, adding 36 hours to 1971-12-31 at noon when the Epoch is initialized in UTC will lead to a different epoch than adding that same duration to an epoch initialized at the same time in TAI (because the first leap second announced by IERS was on 1972-01-01), cf. the `test_add_durations_over_leap_seconds` test.

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -750,6 +750,7 @@ impl Duration {
 }
 
 #[cfg(feature = "std")]
+#[cfg(not(kani))]
 impl<'de> Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -28,6 +28,9 @@ use core::str::FromStr;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "python")]
+use pyo3::pyclass::CompareOp;
+
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 
@@ -286,24 +289,11 @@ impl Duration {
         }
     }
 
-    #[cfg(feature = "python")]
-    #[staticmethod]
-    /// Create a normalized duration from its parts
-    pub fn init_from_parts(centuries: i16, nanoseconds: u64) -> Self {
-        Self::from_parts(centuries, nanoseconds)
-    }
-
     #[must_use]
     /// Returns the centuries and nanoseconds of this duration
     /// NOTE: These items are not public to prevent incorrect durations from being created by modifying the values of the structure directly.
     pub const fn to_parts(&self) -> (i16, u64) {
         (self.centuries, self.nanoseconds)
-    }
-
-    #[cfg(feature = "python")]
-    #[staticmethod]
-    pub fn init_from_total_nanoseconds(nanos: i128) -> Self {
-        Self::from_total_nanoseconds(nanos)
     }
 
     /// Returns the total nanoseconds in a signed 128 bit integer
@@ -319,13 +309,6 @@ impl Duration {
             i128::from(self.centuries) * i128::from(NANOSECONDS_PER_CENTURY)
                 - i128::from(self.nanoseconds)
         }
-    }
-
-    #[cfg(feature = "python")]
-    #[staticmethod]
-    /// Create a new duration from the truncated nanoseconds (+/- 2927.1 years of duration)
-    pub fn init_from_truncated_nanoseconds(nanos: i64) -> Self {
-        Self::from_truncated_nanoseconds(nanos)
     }
 
     /// Returns the truncated nanoseconds in a signed 64 bit integer, if the duration fits.
@@ -401,33 +384,6 @@ impl Duration {
     #[must_use]
     pub const fn signum(&self) -> i8 {
         self.centuries.signum() as i8
-    }
-
-    /// Creates a new duration from its parts
-    #[allow(clippy::too_many_arguments)]
-    #[cfg(feature = "python")]
-    #[staticmethod]
-    #[must_use]
-    pub fn init_from_all_parts(
-        sign: i8,
-        days: u64,
-        hours: u64,
-        minutes: u64,
-        seconds: u64,
-        milliseconds: u64,
-        microseconds: u64,
-        nanoseconds: u64,
-    ) -> Self {
-        Self::compose(
-            sign,
-            days,
-            hours,
-            minutes,
-            seconds,
-            milliseconds,
-            microseconds,
-            nanoseconds,
-        )
     }
 
     /// Decomposes a Duration in its sign, days, hours, minutes, seconds, ms, us, ns
@@ -569,6 +525,44 @@ impl Duration {
         }
     }
 
+    /// Returns the minimum of the two durations.
+    ///
+    /// ```
+    /// use hifitime::TimeUnits;
+    ///
+    /// let d0 = 20.seconds();
+    /// let d1 = 21.seconds();
+    ///
+    /// assert_eq!(d0, d1.min(d0));
+    /// assert_eq!(d0, d0.min(d1));
+    /// ```
+    pub fn min(self, other: Self) -> Self {
+        if self < other {
+            self
+        } else {
+            other
+        }
+    }
+
+    /// Returns the maximum of the two durations.
+    ///
+    /// ```
+    /// use hifitime::TimeUnits;
+    ///
+    /// let d0 = 20.seconds();
+    /// let d1 = 21.seconds();
+    ///
+    /// assert_eq!(d1, d1.max(d0));
+    /// assert_eq!(d1, d0.max(d1));
+    /// ```
+    pub fn max(self, other: Self) -> Self {
+        if self > other {
+            self
+        } else {
+            other
+        }
+    }
+
     /// Returns whether this is a negative or positive duration.
     pub const fn is_negative(&self) -> bool {
         self.centuries.is_negative()
@@ -649,6 +643,25 @@ impl Duration {
     }
 
     #[cfg(feature = "python")]
+    fn __eq__(&self, other: Self) -> bool {
+        *self == other
+    }
+
+    #[cfg(feature = "python")]
+    fn __richcmp__(&self, other: Self, op: CompareOp) -> bool {
+        match op {
+            CompareOp::Lt => *self < other,
+            CompareOp::Le => *self <= other,
+            CompareOp::Eq => *self == other,
+            CompareOp::Ne => *self != other,
+            CompareOp::Gt => *self > other,
+            CompareOp::Ge => *self >= other,
+        }
+    }
+
+    // Python constructors
+
+    #[cfg(feature = "python")]
     #[staticmethod]
     fn zero() -> Duration {
         Duration::ZERO
@@ -682,6 +695,53 @@ impl Duration {
     #[staticmethod]
     fn min_negative() -> Duration {
         Duration::MIN_NEGATIVE
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    /// Create a normalized duration from its parts
+    fn init_from_parts(centuries: i16, nanoseconds: u64) -> Self {
+        Self::from_parts(centuries, nanoseconds)
+    }
+
+    /// Creates a new duration from its parts
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    #[must_use]
+    fn init_from_all_parts(
+        sign: i8,
+        days: u64,
+        hours: u64,
+        minutes: u64,
+        seconds: u64,
+        milliseconds: u64,
+        microseconds: u64,
+        nanoseconds: u64,
+    ) -> Self {
+        Self::compose(
+            sign,
+            days,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+            microseconds,
+            nanoseconds,
+        )
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    fn init_from_total_nanoseconds(nanos: i128) -> Self {
+        Self::from_total_nanoseconds(nanos)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    /// Create a new duration from the truncated nanoseconds (+/- 2927.1 years of duration)
+    fn init_from_truncated_nanoseconds(nanos: i64) -> Self {
+        Self::from_truncated_nanoseconds(nanos)
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -536,9 +536,11 @@ impl Duration {
     /// assert_eq!(d0, d1.min(d0));
     /// assert_eq!(d0, d0.min(d1));
     /// ```
-    pub fn min(self, other: Self) -> Self {
-        if self < other {
-            self
+    ///
+    /// _Note:_ this uses a pointer to `self` which will be copied immediately because Python requires a pointer.
+    pub fn min(&self, other: Self) -> Self {
+        if *self < other {
+            *self
         } else {
             other
         }
@@ -555,9 +557,11 @@ impl Duration {
     /// assert_eq!(d1, d1.max(d0));
     /// assert_eq!(d1, d0.max(d1));
     /// ```
-    pub fn max(self, other: Self) -> Self {
-        if self > other {
-            self
+    ///
+    /// _Note:_ this uses a pointer to `self` which will be copied immediately because Python requires a pointer.
+    pub fn max(&self, other: Self) -> Self {
+        if *self > other {
+            *self
         } else {
             other
         }
@@ -675,13 +679,13 @@ impl Duration {
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    fn max() -> Duration {
+    fn init_from_max() -> Duration {
         Duration::MAX
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    fn min() -> Duration {
+    fn init_from_min() -> Duration {
         Duration::MIN
     }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -24,6 +24,9 @@ use crate::ParsingErrors;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "python")]
+use pyo3::pyclass::CompareOp;
+
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer};
 
@@ -1078,93 +1081,93 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Creates a new Epoch from a Duration as the time difference between this epoch and TAI reference epoch.
-    pub const fn init_from_tai_duration(duration: Duration) -> Self {
+    const fn init_from_tai_duration(duration: Duration) -> Self {
         Self::from_tai_duration(duration)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Creates a new Epoch from its centuries and nanosecond since the TAI reference epoch.
-    pub fn init_from_tai_parts(centuries: i16, nanoseconds: u64) -> Self {
+    fn init_from_tai_parts(centuries: i16, nanoseconds: u64) -> Self {
         Self::from_tai_parts(centuries, nanoseconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided TAI seconds since 1900 January 01 at midnight
-    pub fn init_from_tai_seconds(seconds: f64) -> Self {
+    fn init_from_tai_seconds(seconds: f64) -> Self {
         Self::from_tai_seconds(seconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided TAI days since 1900 January 01 at midnight
-    pub fn init_from_tai_days(days: f64) -> Self {
+    fn init_from_tai_days(days: f64) -> Self {
         Self::from_tai_days(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
-    pub fn init_from_utc_seconds(seconds: f64) -> Self {
+    fn init_from_utc_seconds(seconds: f64) -> Self {
         Self::from_utc_seconds(seconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided UTC days since 1900 January 01 at midnight
-    pub fn init_from_utc_days(days: f64) -> Self {
+    fn init_from_utc_days(days: f64) -> Self {
         Self::from_utc_days(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn init_from_mjd_tai(days: f64) -> Self {
+    fn init_from_mjd_tai(days: f64) -> Self {
         Self::from_mjd_tai(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn init_from_mjd_utc(days: f64) -> Self {
+    fn init_from_mjd_utc(days: f64) -> Self {
         Self::from_mjd_utc(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn init_from_jde_tai(days: f64) -> Self {
+    fn init_from_jde_tai(days: f64) -> Self {
         Self::from_jde_tai(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn init_from_jde_utc(days: f64) -> Self {
+    fn init_from_jde_utc(days: f64) -> Self {
         Self::from_jde_utc(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
-    pub fn init_from_tt_seconds(seconds: f64) -> Self {
+    fn init_from_tt_seconds(seconds: f64) -> Self {
         Self::from_tt_seconds(seconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
-    pub fn init_from_tt_duration(duration: Duration) -> Self {
+    fn init_from_tt_duration(duration: Duration) -> Self {
         Self::from_tt_duration(duration)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the Ephemeris Time seconds past 2000 JAN 01 (J2000 reference)
-    pub fn init_from_et_seconds(seconds_since_j2000: f64) -> Epoch {
+    fn init_from_et_seconds(seconds_since_j2000: f64) -> Epoch {
         Self::from_et_seconds(seconds_since_j2000)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn init_from_et_duration(duration_since_j2000: Duration) -> Self {
+    fn init_from_et_duration(duration_since_j2000: Duration) -> Self {
         Self::from_et_duration(duration_since_j2000)
     }
 
@@ -1173,28 +1176,28 @@ impl Epoch {
     /// Initialize an Epoch from Dynamic Barycentric Time (TDB) seconds past 2000 JAN 01 midnight (difference than SPICE)
     /// NOTE: This uses the ESA algorithm, which is a notch more complicated than the SPICE algorithm, but more precise.
     /// In fact, SPICE algorithm is precise +/- 30 microseconds for a century whereas ESA algorithm should be exactly correct.
-    pub fn init_from_tdb_seconds(seconds_j2000: f64) -> Epoch {
+    fn init_from_tdb_seconds(seconds_j2000: f64) -> Epoch {
         Self::from_tdb_seconds(seconds_j2000)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) whose epoch is 2000 JAN 01 noon TAI.
-    pub fn init_from_tdb_duration(duration_since_j2000: Duration) -> Epoch {
+    fn init_from_tdb_duration(duration_since_j2000: Duration) -> Epoch {
         Self::from_tdb_duration(duration_since_j2000)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from the JDE days
-    pub fn init_from_jde_et(days: f64) -> Self {
+    fn init_from_jde_et(days: f64) -> Self {
         Self::from_jde_et(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) in JD days
-    pub fn init_from_jde_tdb(days: f64) -> Self {
+    fn init_from_jde_tdb(days: f64) -> Self {
         Self::from_jde_tdb(days)
     }
 
@@ -1202,7 +1205,7 @@ impl Epoch {
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the GPS Time Epoch,
     /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn init_from_gpst_seconds(seconds: f64) -> Self {
+    fn init_from_gpst_seconds(seconds: f64) -> Self {
         Self::from_gpst_seconds(seconds)
     }
 
@@ -1210,7 +1213,7 @@ impl Epoch {
     #[staticmethod]
     /// Initialize an Epoch from the number of days since the GPS Time Epoch,
     /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn init_from_gpst_days(days: f64) -> Self {
+    fn init_from_gpst_days(days: f64) -> Self {
         Self::from_gpst_days(days)
     }
 
@@ -1219,28 +1222,55 @@ impl Epoch {
     /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
     /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
     /// This may be useful for time keeping devices that use GPS as a time source.
-    pub fn init_from_gpst_nanoseconds(nanoseconds: u64) -> Self {
+    fn init_from_gpst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_gpst_nanoseconds(nanoseconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided UNIX second timestamp since UTC midnight 1970 January 01.
-    pub fn init_from_unix_seconds(seconds: f64) -> Self {
+    fn init_from_unix_seconds(seconds: f64) -> Self {
         Self::from_unix_seconds(seconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the provided UNIX millisecond timestamp since UTC midnight 1970 January 01.
-    pub fn init_from_unix_milliseconds(milliseconds: f64) -> Self {
+    fn init_from_unix_milliseconds(milliseconds: f64) -> Self {
         Self::from_unix_milliseconds(milliseconds)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    fn init_from_gregorian(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanos: u32,
+        ts: TimeScale,
+    ) -> Self {
+        Self::from_gregorian(year, month, day, hour, minute, second, nanos, ts)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    fn init_from_gregorian_at_noon(year: i32, month: u8, day: u8, ts: TimeScale) -> Self {
+        Self::from_gregorian_at_noon(year, month, day, ts)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    fn init_from_gregorian_at_midnight(year: i32, month: u8, day: u8, ts: TimeScale) -> Self {
+        Self::from_gregorian_at_midnight(year, month, day, ts)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
     /// Attempts to build an Epoch from the provided Gregorian date and time in TAI.
-    pub fn maybe_init_from_gregorian_tai(
+    fn maybe_init_from_gregorian_tai(
         year: i32,
         month: u8,
         day: u8,
@@ -1257,7 +1287,7 @@ impl Epoch {
     /// Attempts to build an Epoch from the provided Gregorian date and time in the provided time system.
     /// NOTE: If the timesystem is TDB, this function assumes that the SPICE format is used
     #[allow(clippy::too_many_arguments)]
-    pub fn maybe_init_from_gregorian(
+    fn maybe_init_from_gregorian(
         year: i32,
         month: u8,
         day: u8,
@@ -1274,7 +1304,7 @@ impl Epoch {
     #[staticmethod]
     /// Builds an Epoch from the provided Gregorian date and time in TAI. If invalid date is provided, this function will panic.
     /// Use maybe_from_gregorian_tai if unsure.
-    pub fn init_from_gregorian_tai(
+    fn init_from_gregorian_tai(
         year: i32,
         month: u8,
         day: u8,
@@ -1289,21 +1319,21 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from the Gregoerian date at midnight in TAI.
-    pub fn init_from_gregorian_tai_at_midnight(year: i32, month: u8, day: u8) -> Self {
+    fn init_from_gregorian_tai_at_midnight(year: i32, month: u8, day: u8) -> Self {
         Self::from_gregorian_tai_at_midnight(year, month, day)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from the Gregorian date at noon in TAI
-    pub fn init_from_gregorian_tai_at_noon(year: i32, month: u8, day: u8) -> Self {
+    fn init_from_gregorian_tai_at_noon(year: i32, month: u8, day: u8) -> Self {
         Self::from_gregorian_tai_at_noon(year, month, day)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from the Gregorian date and time (without the nanoseconds) in TAI
-    pub fn init_from_gregorian_tai_hms(
+    fn init_from_gregorian_tai_hms(
         year: i32,
         month: u8,
         day: u8,
@@ -1317,7 +1347,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Attempts to build an Epoch from the provided Gregorian date and time in UTC.
-    pub fn maybe_init_from_gregorian_utc(
+    fn maybe_init_from_gregorian_utc(
         year: i32,
         month: u8,
         day: u8,
@@ -1333,7 +1363,7 @@ impl Epoch {
     #[staticmethod]
     /// Builds an Epoch from the provided Gregorian date and time in TAI. If invalid date is provided, this function will panic.
     /// Use maybe_from_gregorian_tai if unsure.
-    pub fn init_from_gregorian_utc(
+    fn init_from_gregorian_utc(
         year: i32,
         month: u8,
         day: u8,
@@ -1348,21 +1378,21 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from Gregorian date in UTC at midnight
-    pub fn init_from_gregorian_utc_at_midnight(year: i32, month: u8, day: u8) -> Self {
+    fn init_from_gregorian_utc_at_midnight(year: i32, month: u8, day: u8) -> Self {
         Self::from_gregorian_utc_at_midnight(year, month, day)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from Gregorian date in UTC at noon
-    pub fn init_from_gregorian_utc_at_noon(year: i32, month: u8, day: u8) -> Self {
+    fn init_from_gregorian_utc_at_noon(year: i32, month: u8, day: u8) -> Self {
         Self::from_gregorian_utc_at_noon(year, month, day)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize from the Gregorian date and time (without the nanoseconds) in UTC
-    pub fn init_from_gregorian_utc_hms(
+    fn init_from_gregorian_utc_hms(
         year: i32,
         month: u8,
         day: u8,
@@ -1965,7 +1995,7 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    pub fn system_now() -> Result<Self, Errors> {
+    fn system_now() -> Result<Self, Errors> {
         Self::now()
     }
 
@@ -1990,44 +2020,37 @@ impl Epoch {
     }
 
     #[cfg(feature = "python")]
-    /// Converts the Epoch to UTC Gregorian in the ISO8601 format.
-    pub fn to_string_gregorian_utc(&self) -> String {
-        self.to_gregorian_utc_str()
+    fn timedelta(&self, other: Self) -> Duration {
+        *self - other
     }
 
     #[cfg(feature = "python")]
-    /// Converts the Epoch to TAI Gregorian in the ISO8601 format.
-    pub fn to_string_gregorian_tai(&self) -> String {
-        self.to_gregorian_tai_str()
+    fn __richcmp__(&self, other: Self, op: CompareOp) -> bool {
+        match op {
+            CompareOp::Lt => *self < other,
+            CompareOp::Le => *self <= other,
+            CompareOp::Eq => *self == other,
+            CompareOp::Ne => *self != other,
+            CompareOp::Gt => *self > other,
+            CompareOp::Ge => *self >= other,
+        }
     }
 
-    #[cfg(feature = "python")]
-    /// Converts the Epoch to Gregorian in the ISO8601 format in the provided TimeSystem
-    pub fn to_string_gregorian(&self, ts: TimeScale) -> String {
-        self.to_gregorian_str(ts)
-    }
-
-    #[cfg(feature = "python")]
-    /// Converts the Epoch to Gregorian in the RFC3339 format in the provided TimeSystem
-    pub fn rfc3339(&self) -> String {
-        self.to_rfc3339()
-    }
-}
-
-#[cfg(feature = "std")]
-impl Epoch {
+    #[cfg(feature = "std")]
     #[must_use]
     /// Converts the Epoch to UTC Gregorian in the ISO8601 format.
     pub fn to_gregorian_utc_str(&self) -> String {
         format!("{}", self)
     }
 
+    #[cfg(feature = "std")]
     #[must_use]
     /// Converts the Epoch to TAI Gregorian in the ISO8601 format with " TAI" appended to the string
     pub fn to_gregorian_tai_str(&self) -> String {
         format!("{:x}", self)
     }
 
+    #[cfg(feature = "std")]
     #[must_use]
     /// Converts the Epoch to Gregorian in the provided time system and in the ISO8601 format with the time system appended to the string
     pub fn to_gregorian_str(&self, ts: TimeScale) -> String {
@@ -2052,16 +2075,7 @@ impl Epoch {
         }
     }
 
-    /// Initializes a new Epoch from `now`.
-    /// WARNING: This assumes that the system time returns the time in UTC (which is the case on Linux)
-    /// Uses [`std::time::SystemTime::now`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now) under the hood
-    pub fn now() -> Result<Self, Errors> {
-        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-            Ok(std_duration) => Ok(Self::from_unix_seconds(std_duration.as_secs_f64())),
-            Err(_) => Err(Errors::SystemTimeError),
-        }
-    }
-
+    #[cfg(feature = "std")]
     /// Returns this epoch in UTC in the RFC3339 format
     pub fn to_rfc3339(&self) -> String {
         let (y, mm, dd, hh, min, s, nanos) = Self::compute_gregorian(self.to_utc_duration());
@@ -2075,6 +2089,58 @@ impl Epoch {
                 "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:09}+00:00",
                 y, mm, dd, hh, min, s, nanos
             )
+        }
+    }
+
+    /// Returns the minimum of the two epochs.
+    ///
+    /// ```
+    /// use hifitime::Epoch;
+    ///
+    /// let e0 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 20);
+    /// let e1 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 21);
+    ///
+    /// assert_eq!(e0, e1.min(e0));
+    /// assert_eq!(e0, e0.min(e1));
+    /// ```
+    pub fn min(self, other: Self) -> Self {
+        if self < other {
+            self
+        } else {
+            other
+        }
+    }
+
+    /// Returns the maximum of the two epochs.
+    ///
+    /// ```
+    /// use hifitime::Epoch;
+    ///
+    /// let e0 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 20);
+    /// let e1 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 21);
+    ///
+    /// assert_eq!(e1, e1.max(e0));
+    /// assert_eq!(e1, e0.max(e1));
+    /// ```
+    pub fn max(self, other: Self) -> Self {
+        if self > other {
+            self
+        } else {
+            other
+        }
+    }
+}
+
+// This is in its separate impl far away from the Python feature because pyO3's staticmethod does not work with cfg_attr
+#[cfg(feature = "std")]
+impl Epoch {
+    /// Initializes a new Epoch from `now`.
+    /// WARNING: This assumes that the system time returns the time in UTC (which is the case on Linux)
+    /// Uses [`std::time::SystemTime::now`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now) under the hood
+    pub fn now() -> Result<Self, Errors> {
+        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(std_duration) => Ok(Self::from_unix_seconds(std_duration.as_secs_f64())),
+            Err(_) => Err(Errors::SystemTimeError),
         }
     }
 }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -826,6 +826,7 @@ impl Epoch {
     ///     Epoch::from_gregorian_str("1994-11-05T08:15:30-05:00").unwrap()
     /// );
     /// ```
+    #[cfg(not(kani))]
     pub fn from_gregorian_str(s_in: &str) -> Result<Self, Errors> {
         // All of the integers in a date: year, month, day, hour, minute, second, subsecond, offset hours, offset minutes
         let mut decomposed = [0_i32; 9];
@@ -2149,6 +2150,7 @@ impl Epoch {
     }
 }
 
+#[cfg(not(kani))]
 impl FromStr for Epoch {
     type Err = Errors;
 
@@ -2226,6 +2228,7 @@ impl FromStr for Epoch {
 }
 
 #[cfg(feature = "std")]
+#[cfg(not(kani))]
 impl<'de> Deserialize<'de> for Epoch {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2103,9 +2103,11 @@ impl Epoch {
     /// assert_eq!(e0, e1.min(e0));
     /// assert_eq!(e0, e0.min(e1));
     /// ```
-    pub fn min(self, other: Self) -> Self {
-        if self < other {
-            self
+    ///
+    /// _Note:_ this uses a pointer to `self` which will be copied immediately because Python requires a pointer.
+    pub fn min(&self, other: Self) -> Self {
+        if *self < other {
+            *self
         } else {
             other
         }
@@ -2122,9 +2124,11 @@ impl Epoch {
     /// assert_eq!(e1, e1.max(e0));
     /// assert_eq!(e1, e0.max(e1));
     /// ```
-    pub fn max(self, other: Self) -> Self {
-        if self > other {
-            self
+    ///
+    /// _Note:_ this uses a pointer to `self` which will be copied immediately because Python requires a pointer.
+    pub fn max(&self, other: Self) -> Self {
+        if *self > other {
+            *self
         } else {
             other
         }

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -105,6 +105,108 @@ impl fmt::Display for TimeSeries {
     }
 }
 
+impl fmt::LowerHex for TimeSeries {
+    /// Prints the Epoch in TAI
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:x} : {:x} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
+impl fmt::UpperHex for TimeSeries {
+    /// Prints the Epoch in TT
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:X} : {:X} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
+impl fmt::LowerExp for TimeSeries {
+    /// Prints the Epoch in TDB
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:e} : {:e} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
+impl fmt::UpperExp for TimeSeries {
+    /// Prints the Epoch in ET
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:E} : {:E} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
+impl fmt::Pointer for TimeSeries {
+    /// Prints the Epoch in UNIX
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:p} : {:p} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
+impl fmt::Octal for TimeSeries {
+    /// Prints the Epoch in GPS
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TimeSeries [{:o} : {:o} : {}]",
+            self.start,
+            if self.incl {
+                self.end
+            } else {
+                self.end - self.step
+            },
+            self.step
+        )
+    }
+}
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl TimeSeries {

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -39,6 +39,7 @@ pub enum Unit {
 
 /// An Enum to convert frequencies to their approximate duration, **rounded to the closest nanosecond**.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "python", pyclass)]
 pub enum Freq {
     GigaHertz,
     MegaHertz,
@@ -94,7 +95,6 @@ pub trait TimeUnits: Copy + Mul<Unit, Output = Duration> {
 ///
 /// ```
 /// use hifitime::prelude::*;
-/// use std::str::FromStr;
 ///
 /// assert_eq!(1.Hz(), 1.seconds());
 /// assert_eq!(10.Hz(), 0.1.seconds());

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -446,6 +446,7 @@ fn test_decompose() {
     let neg = -(5 * Unit::Hour + 256 * Unit::Millisecond + Unit::Nanosecond);
     assert_eq!(neg, -pos);
     assert_eq!(neg.abs(), pos);
+    assert!(neg.is_negative());
 
     let (sign, days, hours, minutes, seconds, milliseconds, microseconds, nanos) = neg.decompose();
     assert_eq!(sign, -1);
@@ -456,4 +457,18 @@ fn test_decompose() {
     assert_eq!(milliseconds, 256);
     assert_eq!(microseconds, 0);
     assert_eq!(nanos, 1);
+}
+
+#[test]
+fn test_minmax() {
+    use hifitime::TimeUnits;
+
+    let d0 = 20.seconds();
+    let d1 = 21.seconds();
+
+    assert_eq!(d0, d1.min(d0));
+    assert_eq!(d0, d0.min(d1));
+
+    assert_eq!(d1, d1.max(d0));
+    assert_eq!(d1, d0.max(d1));
 }

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -1220,3 +1220,17 @@ fn from_infinite_jde_tdb_days() {
 fn from_infinite_tdb_seconds() {
     let _ = Epoch::from_tdb_seconds(f64::NAN);
 }
+
+#[test]
+fn test_minmax() {
+    use hifitime::Epoch;
+
+    let e0 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 20);
+    let e1 = Epoch::from_gregorian_utc_at_midnight(2022, 10, 21);
+
+    assert_eq!(e0, e1.min(e0));
+    assert_eq!(e0, e0.min(e1));
+
+    assert_eq!(e1, e1.max(e0));
+    assert_eq!(e1, e0.max(e1));
+}

--- a/tests/timeseries.rs
+++ b/tests/timeseries.rs
@@ -16,6 +16,36 @@ fn test_timeseries() {
         "TimeSeries [2017-01-14T00:00:00 UTC : 2017-01-14T10:00:00 UTC : 2 h]"
     );
 
+    assert_eq!(
+        format!("{:x}", time_series),
+        "TimeSeries [2017-01-14T00:00:37 TAI : 2017-01-14T10:00:37 TAI : 2 h]"
+    );
+
+    assert_eq!(
+        format!("{:X}", time_series),
+        "TimeSeries [2017-01-14T00:01:09.184000000 TT : 2017-01-14T10:01:09.184000000 TT : 2 h]"
+    );
+
+    assert_eq!(
+        format!("{:e}", time_series),
+        "TimeSeries [2017-01-14T00:01:09.184299750 TDB : 2017-01-14T10:01:09.184311622 TDB : 2 h]"
+    );
+
+    assert_eq!(
+        format!("{:E}", time_series),
+        "TimeSeries [2017-01-14T00:01:09.184304724 ET : 2017-01-14T10:01:09.184316581 ET : 2 h]"
+    );
+
+    assert_eq!(
+        format!("{:o}", time_series),
+        "TimeSeries [1168387218000000000 : 1168423218000000000 : 2 h]"
+    );
+
+    assert_eq!(
+        format!("{:p}", time_series),
+        "TimeSeries [1484352000 : 1484388000 : 2 h]"
+    );
+
     for epoch in time_series {
         if count == 0 {
             assert_eq!(
@@ -78,7 +108,6 @@ fn gh131_regression() {
 fn gh154_reciprocity() {
     use core::str::FromStr;
 
-    // TODO: Reproduce for all time scales
     for epoch in TimeSeries::inclusive(
         Epoch::from_str("1970-03-02T00:00:00 UTC").unwrap(),
         Epoch::from_str("2023-01-01 00:00:00 UTC").unwrap(),


### PR DESCRIPTION
+ Epoch and Duration now have a `min` and `max` function which respectively returns a copy of the epoch/duration that is the smallest or the largest between `self` and `other`, cf. [#164](https://github.com/nyx-space/hifitime/issues/164).
+ [Python] Duration and Epochs now support the operators `>`, `>=`, `<`, `<=`, `==`, and `!=`. Epoch now supports `init_from_gregorian` with a time scape, like in Rust. Epochs can also be subtracted from one another using the `timedelta` function, cf. [#162](https://github.com/nyx-space/hifitime/issues/162).
+ TimeSeries can now be formatted in different time scales, cf. [#163](https://github.com/nyx-space/hifitime/issues/163)

Closes #162 
Closes #163 
Closes #164 