### PR TITLE
introducing GNSS timescales

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifitime"
-version = "3.5.0"
+version = "3.6.0"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Put this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-hifitime = "3.5"
+hifitime = "3.6"
 ```
 
 ## Examples:
@@ -284,7 +284,7 @@ In order to provide full interoperability with NAIF, hifitime uses the NAIF algo
 
 # Changelog
 
-## 3.5.1
+## 3.6.0
 + Galileo System Time and BeiDou Time are now supported, huge thanks to [@gwbres](https://github.com/gwbres) for all that work!
 + Significant speed improvement in the initialization of Epochs from their Gregorian representation, thanks [@conradludgate](https://github.com/conradludgate) for [#160](https://github.com/nyx-space/hifitime/pull/160).
 + Epoch and Duration now have a `min` and `max` function which respectively returns a copy of the epoch/duration that is the smallest or the largest between `self` and `other`, cf. [#164](https://github.com/nyx-space/hifitime/issues/164).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ This library is validated against NASA/NAIF SPICE for the Ephemeris Time to Univ
 + Terrestrial Time (TT)
 + Ephemeris Time (ET) without the small perturbations as per NASA/NAIF SPICE leap seconds kernel
 + Dynamic Barycentric Time (TDB), a higher fidelity ephemeris time
-+ Global Positioning System (GPS), and UNIX
++ Global Positioning System (GPST)
++ Galileo System Time (GST)
++ BaiDou Time (BDT)
++ UNIX
 ## Non-features
 * Time-agnostic / date-only epochs. Hifitime only supports the combination of date and time, but the `Epoch::{at_midnight, at_noon}` is provided as a helper function.
 
@@ -282,6 +285,7 @@ In order to provide full interoperability with NAIF, hifitime uses the NAIF algo
 # Changelog
 
 ## 3.5.1
++ Galileo System Time and BeiDou Time are now supported, huge thanks to [@gwbres](https://github.com/gwbres) for all that work!
 + Significant speed improvement in the initialization of Epochs from their Gregorian representation, thanks [@conradludgate](https://github.com/conradludgate) for [#160](https://github.com/nyx-space/hifitime/pull/160).
 + Epoch and Duration now have a `min` and `max` function which respectively returns a copy of the epoch/duration that is the smallest or the largest between `self` and `other`, cf. [#164](https://github.com/nyx-space/hifitime/issues/164).
 + [Python] Duration and Epochs now support the operators `>`, `>=`, `<`, `<=`, `==`, and `!=`. Epoch now supports `init_from_gregorian` with a time scape, like in Rust. Epochs can also be subtracted from one another using the `timedelta` function, cf. [#162](https://github.com/nyx-space/hifitime/issues/162).

--- a/benches/bench_epoch.rs
+++ b/benches/bench_epoch.rs
@@ -6,29 +6,29 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("TBD seconds and JDE ET", |b| {
         b.iter(|| {
             let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);
-            black_box(Epoch::from_tdb_seconds(e.as_tdb_seconds()));
-            black_box(Epoch::from_jde_et(e.as_jde_et_days()));
+            black_box(Epoch::from_tdb_seconds(e.to_tdb_seconds()));
+            black_box(Epoch::from_jde_et(e.to_jde_et_days()));
 
             let f: Epoch = e + black_box(50) * Unit::Second;
-            black_box(f.as_tdb_seconds());
-            black_box(f.as_jde_et_days());
+            black_box(f.to_tdb_seconds());
+            black_box(f.to_jde_et_days());
         })
     });
 
     c.bench_function("TT", |b| {
         b.iter(|| {
             let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);
-            e.as_tt_seconds();
+            e.to_tt_seconds();
 
             let f: Epoch = e + black_box(50) * Unit::Second;
-            f.as_tt_seconds();
+            f.to_tt_seconds();
         })
     });
 
     c.bench_function("Duration to f64 seconds", |b| {
         b.iter(|| {
             let d: Duration = Unit::Second * black_box(3.0);
-            d.in_seconds();
+            d.to_seconds();
         })
     });
 

--- a/examples/python/basic.py
+++ b/examples/python/basic.py
@@ -47,3 +47,9 @@ if __name__ == "__main__":
     print(time_series)
     for (num, epoch) in enumerate(time_series):
         print(f"#{num}:\t{epoch}")
+
+    e1 = Epoch.system_now()
+    e3 = e1 + Unit.Day * 1.5998
+    epoch_delta = e3.timedelta(e1)
+    assert epoch_delta == Unit.Day * 1 + Unit.Hour * 14 + Unit.Minute * 23 + Unit.Second * 42.720
+    print(epoch_delta)

--- a/src/asn1der.rs
+++ b/src/asn1der.rs
@@ -92,7 +92,7 @@ impl<'a> Decode<'a> for Unit {
 // Testing the encoding and decoding of an Epoch inherently also tests the encoding and decoding of a Duration
 #[test]
 fn test_encdec() {
-    for ts_u8 in 0..5 {
+    for ts_u8 in 0..=7 {
         let ts: TimeScale = ts_u8.into();
 
         let epoch = if ts == TimeScale::UTC {
@@ -134,7 +134,7 @@ fn test_encdec() {
         );
     }
 
-    for unit_u8 in 0..8 {
+    for unit_u8 in 0..=7 {
         let unit: Unit = unit_u8.into();
 
         // Create a buffer

--- a/src/asn1der.rs
+++ b/src/asn1der.rs
@@ -62,6 +62,9 @@ impl<'a> Decode<'a> for Epoch {
             TimeScale::ET => Self::from_et_duration(duration),
             TimeScale::TDB => Self::from_tdb_duration(duration),
             TimeScale::UTC => Self::from_utc_duration(duration),
+            TimeScale::GPST => Self::from_gpst_duration(duration),
+            TimeScale::GST => Self::from_gst_duration(duration), 
+            TimeScale::BDT => Self::from_bdt_duration(duration), 
         })
     }
 }
@@ -104,6 +107,9 @@ fn test_encdec() {
             TimeScale::TT => epoch.to_tt_duration(),
             TimeScale::TDB => epoch.to_tdb_duration(),
             TimeScale::UTC => epoch.to_utc_duration(),
+            TimeScale::GPST => epoch.to_gpst_duration(),
+            TimeScale::GST => epoch.to_gst_duration(),
+            TimeScale::BDT => epoch.to_bdt_duration(),
         };
 
         let e_dur = epoch.to_duration();

--- a/src/asn1der.rs
+++ b/src/asn1der.rs
@@ -63,8 +63,8 @@ impl<'a> Decode<'a> for Epoch {
             TimeScale::TDB => Self::from_tdb_duration(duration),
             TimeScale::UTC => Self::from_utc_duration(duration),
             TimeScale::GPST => Self::from_gpst_duration(duration),
-            TimeScale::GST => Self::from_gst_duration(duration), 
-            TimeScale::BDT => Self::from_bdt_duration(duration), 
+            TimeScale::GST => Self::from_gst_duration(duration),
+            TimeScale::BDT => Self::from_bdt_duration(duration),
         })
     }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -92,7 +92,7 @@ impl Default for Duration {
 impl Duration {
     /// Builds a new duration from the number of centuries and the number of nanoseconds
     #[must_use]
-    #[deprecated(note = "Prefer from_parts()", since = "3.5.1")]
+    #[deprecated(note = "Prefer from_parts()", since = "3.6.0")]
     pub fn new(centuries: i16, nanoseconds: u64) -> Self {
         let mut out = Self {
             centuries,

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -92,6 +92,7 @@ impl Default for Duration {
 impl Duration {
     /// Builds a new duration from the number of centuries and the number of nanoseconds
     #[must_use]
+    #[deprecated(note = "Prefer from_parts()", since = "3.5.1")]
     pub fn new(centuries: i16, nanoseconds: u64) -> Self {
         let mut out = Self {
             centuries,

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -362,7 +362,7 @@ impl Epoch {
     #[must_use]
     /// Initialize an Epoch from the provided duration since January 1st midnight
     pub fn from_bdt_duration(duration: Duration) -> Self {
-        let mut me = Self::from_utc_duration(BDT_REF_EPOCH.to_utc_duration() + duration);
+        let mut me = Self::from_tai_duration(BDT_REF_EPOCH.to_tai_duration() + duration);
         me.time_scale = TimeScale::BDT;
         me
     }
@@ -1613,6 +1613,7 @@ impl Epoch {
     /// This will return an overflow error if more than one century has past since the reference epoch in the provided time scale.
     /// If this is _not_ an issue, you should use `epoch.to_duration_in_time_scale().to_parts()` to retrieve both the centuries and the nanoseconds
     /// in that century.
+    #[allow(clippy::wrong_self_convention)]
     fn to_nanoseconds_in_time_scale(&self, ts: TimeScale) -> Result<u64, Errors> {
         let (centuries, nanoseconds) = self.to_duration_in_time_scale(ts).to_parts();
         if centuries != 0 {
@@ -1906,7 +1907,7 @@ impl Epoch {
     #[must_use]
     /// Returns `Duration` past BDT (BeiDou) time Epoch.
     pub fn to_bdt_duration(&self) -> Duration {
-        self.to_utc_duration() - BDT_REF_EPOCH.to_utc_duration()
+        self.to_tai_duration() - BDT_REF_EPOCH.to_tai_duration()
     }
 
     #[must_use]

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1638,9 +1638,9 @@ impl Epoch {
             TimeScale::TT => self.to_tt_duration(),
             TimeScale::TDB => self.to_tdb_duration_since_j1900(),
             TimeScale::UTC => self.to_utc_duration(),
-            TimeScale::GPST => self.to_gpst_duration() - GPST_REF_EPOCH.to_tai_duration(),
+            TimeScale::GPST => self.to_gpst_duration() + GPST_REF_EPOCH.to_tai_duration(),
             TimeScale::GST => self.to_gst_duration() + GST_REF_EPOCH.to_tai_duration(),
-            TimeScale::BDT => self.to_bdt_duration() + BDT_REF_EPOCH.to_utc_duration(),
+            TimeScale::BDT => self.to_bdt_duration() + BDT_REF_EPOCH.to_tai_duration(),
         }
     }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -974,9 +974,6 @@ impl Epoch {
                     if idx != s.len() - 1 {
                         // We have some remaining characters, so let's parse those in the only formats we know.
                         ts = TimeScale::from_str(s[idx..].trim())?;
-                        if ts == TimeScale::GPST {
-                            print!("yo");
-                        }
                     }
                     break;
                 }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -590,7 +590,7 @@ impl Epoch {
     /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_days(days: f64) -> Self {
-        Self::from_duration(days * Unit::Nanosecond, TimeScale::GST)
+        Self::from_duration(days * Unit::Day, TimeScale::GST)
     }
 
     #[must_use]
@@ -733,9 +733,15 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::TDB => Self::from_tdb_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::UTC => Self::from_utc_duration(duration_wrt_1900),
-            TimeScale::GPST => Self::from_gpst_duration(duration_wrt_1900),
-            TimeScale::GST => Self::from_gst_duration(duration_wrt_1900),
-            TimeScale::BDT => Self::from_bdt_duration(duration_wrt_1900),
+            TimeScale::GPST => {
+                Self::from_gpst_duration(duration_wrt_1900 - GPST_REF_EPOCH.to_tai_duration())
+            }
+            TimeScale::GST => {
+                Self::from_gst_duration(duration_wrt_1900 - GST_REF_EPOCH.to_tai_duration())
+            }
+            TimeScale::BDT => {
+                Self::from_bdt_duration(duration_wrt_1900 - BDT_REF_EPOCH.to_tai_duration())
+            }
         })
     }
 
@@ -968,6 +974,9 @@ impl Epoch {
                     if idx != s.len() - 1 {
                         // We have some remaining characters, so let's parse those in the only formats we know.
                         ts = TimeScale::from_str(s[idx..].trim())?;
+                        if ts == TimeScale::GPST {
+                            print!("yo");
+                        }
                     }
                     break;
                 }
@@ -1355,7 +1364,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the Galileo Time Epoch,
-    /// starting on August 21st 1999 Midnight UTC,
+    /// starting on August 21st 1999 Midnight UT,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_seconds(seconds: f64) -> Self {
         Self::from_gst_seconds(seconds)
@@ -1364,7 +1373,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of days since the Galileo Time Epoch,
-    /// starting on August 21st 1999 Midnight UTC,
+    /// starting on August 21st 1999 Midnight UT,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_days(days: f64) -> Self {
         Self::from_gst_days(days)
@@ -1373,7 +1382,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of nanoseconds since the Galileo Time Epoch,
-    /// starting on August 21st 1999 Midnight UTC,
+    /// starting on August 21st 1999 Midnight UT,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// This may be useful for time keeping devices that use GST as a time source.
     fn init_from_gst_nanoseconds(nanoseconds: u64) -> Self {
@@ -1885,13 +1894,13 @@ impl Epoch {
 
     #[must_use]
     /// Returns days past GST (Galileo) Time Epoch,
-    /// starting on August 21st 1999 Midnight UTC
+    /// starting on August 21st 1999 Midnight UT
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     pub fn to_gst_days(&self) -> f64 {
         self.to_gst_duration().to_unit(Unit::Day)
     }
 
-    /// Returns nanoseconds past GST (Galileo) Time Epoch, starting on August 21st 1999 Midnight UTC
+    /// Returns nanoseconds past GST (Galileo) Time Epoch, starting on August 21st 1999 Midnight UT
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// NOTE: This function will return an error if the centuries past GST time are not zero.
     pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -569,7 +569,10 @@ impl Epoch {
     /// This may be useful for time keeping devices that use GPS as a time source.
     pub fn from_gpst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_duration(
-            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            Duration {
+                centuries: 0,
+                nanoseconds,
+            },
             TimeScale::GPST,
         )
     }
@@ -579,7 +582,7 @@ impl Epoch {
     /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     pub fn from_gst_seconds(seconds: f64) -> Self {
-        Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::GST)
+        Self::from_duration(seconds * Unit::Second, TimeScale::GST)
     }
 
     #[must_use]
@@ -587,7 +590,7 @@ impl Epoch {
     /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_days(days: f64) -> Self {
-        Self::from_duration(Duration::from_f64(days, Unit::Nanosecond), TimeScale::GST)
+        Self::from_duration(days * Unit::Nanosecond, TimeScale::GST)
     }
 
     #[must_use]
@@ -596,7 +599,10 @@ impl Epoch {
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_duration(
-            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            Duration {
+                centuries: 0,
+                nanoseconds,
+            },
             TimeScale::GST,
         )
     }
@@ -605,14 +611,14 @@ impl Epoch {
     /// Initialize an Epoch from the number of seconds since the BDT Time Epoch,
     /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_bdt_seconds(seconds: f64) -> Self {
-        Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::BDT)
+        Self::from_duration(seconds * Unit::Second, TimeScale::BDT)
     }
 
     #[must_use]
     /// Initialize an Epoch from the number of days since the BDT Time Epoch,
     /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_bdt_days(days: f64) -> Self {
-        Self::from_duration(Duration::from_f64(days, Unit::Day), TimeScale::BDT)
+        Self::from_duration(days * Unit::Day, TimeScale::BDT)
     }
 
     #[must_use]
@@ -621,7 +627,10 @@ impl Epoch {
     /// This may be useful for time keeping devices that use BDT as a time source.
     pub fn from_bdt_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_duration(
-            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            Duration {
+                centuries: 0,
+                nanoseconds,
+            },
             TimeScale::BDT,
         )
     }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -351,7 +351,7 @@ impl Epoch {
     }
     
     #[must_use]
-    /// Initialize an Epoch from the provided duration since 1980 January 6 13 seconds prior midnight 
+    /// Initialize an Epoch from the provided duration since August 21st 1999 midnight
     pub fn from_gst_duration(duration: Duration) -> Self {
         Self::from_duration(duration, TimeScale::GST)
     }
@@ -568,15 +568,15 @@ impl Epoch {
     
     #[must_use]
     /// Initialize an Epoch from the number of seconds since the GST Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
+    /// starting August 21st 1999 midnight (UTC)
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     pub fn from_gst_seconds(seconds: f64) -> Self {
         Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::GST)
     }
     
     #[must_use]
     /// Initialize an Epoch from the number of days since the GST Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
+    /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_days(days: f64) -> Self {
         Self::from_duration(Duration::from_f64(days, Unit::Nanosecond), TimeScale::GST)
@@ -584,7 +584,7 @@ impl Epoch {
 
     #[must_use]
     /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
+    /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_duration(Duration::from_f64(nanoseconds as f64, Unit::Nanosecond), TimeScale::GST)
@@ -1331,7 +1331,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the Galileo Time Epoch,
-    /// defined as 13 seconds prior UTC midnight August 22nd 1999 
+    /// starting on August 21st 1999 Midnight UTC,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_seconds(seconds: f64) -> Self {
         Self::from_gst_seconds(seconds)
@@ -1340,7 +1340,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of days since the Galileo Time Epoch,
-    /// defined as 13 seconds prior UTC midnight August 22nd 1999 
+    /// starting on August 21st 1999 Midnight UTC,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_days(days: f64) -> Self {
         Self::from_gst_days(days)
@@ -1349,7 +1349,7 @@ impl Epoch {
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of nanoseconds since the Galileo Time Epoch,
-    /// defined as 13 seconds prior UTC midnight August 22nd 1999 
+    /// starting on August 21st 1999 Midnight UTC,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// This may be useful for time keeping devices that use GST as a time source.
     fn init_from_gst_nanoseconds(nanoseconds: u64) -> Self {
@@ -1843,25 +1843,39 @@ impl Epoch {
     }
     
     #[must_use]
+    /// Returns seconds past GST (Galileo) Time Epoch
+    pub fn to_gst_seconds(&self) -> f64 {
+        self.to_gst_duration().to_seconds()
+    }
+
+    #[must_use]
     /// Returns `Duration` past GST (Galileo) time Epoch.
     pub fn to_gst_duration(&self) -> Duration {
         self.to_ts_duration(TimeScale::GST)
     }
     
     #[must_use]
-    /// Returns days past GST (Galileo) Time Epoch, defined as 13 seconds prior midnight, August 22nd 1999 UTC
+    /// Returns days past GST (Galileo) Time Epoch,
+    /// starting on August 21st 1999 Midnight UTC
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     pub fn to_gst_days(&self) -> f64 {
         self.to_gst_duration().to_unit(Unit::Day)
     }
     
-    /// Returns nanoseconds past GST (Galileo) Time Epoch, defined as 13 seconds prior midnight, August 22nd 1999 UTC,
+    /// Returns nanoseconds past GST (Galileo) Time Epoch, 
+    /// starting on August 21st 1999 Midnight UTC
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// NOTE: This function will return an error if the centuries past GST time are not zero.
     pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {
         self.to_ts_nanoseconds(TimeScale::GST)
     }
     
+    #[must_use]
+    /// Returns seconds past BDT (BeiDou) Time Epoch
+    pub fn to_bdt_seconds(&self) -> f64 {
+        self.to_bdt_duration().to_seconds()
+    }
+
     #[must_use]
     /// Returns `Duration` past BDT (BeiDou) time Epoch.
     pub fn to_bdt_duration(&self) -> Duration {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2086,13 +2086,10 @@ impl Epoch {
             TimeScale::TAI => {
                 Self::from_tai_duration(self.duration_since_j1900_tai.floor(duration))
             }
-            TimeScale::UTC => Self::from_utc_duration(self.to_utc_duration().floor(duration)),
             TimeScale::ET => Self::from_et_duration(self.to_et_duration().floor(duration)),
             TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().floor(duration)),
             TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().floor(duration)),
-            TimeScale::GPST => Self::from_gpst_duration(self.to_gpst_duration().floor(duration)),
-            TimeScale::GST => Self::from_gst_duration(self.to_gst_duration().floor(duration)),
-            TimeScale::BDT => Self::from_bdt_duration(self.to_bdt_duration().floor(duration)),
+            ts => Self::from_duration(self.to_duration().floor(duration), ts),
         }
     }
 
@@ -2118,13 +2115,10 @@ impl Epoch {
     pub fn ceil(&self, duration: Duration) -> Self {
         match self.time_scale {
             TimeScale::TAI => Self::from_tai_duration(self.duration_since_j1900_tai.ceil(duration)),
-            TimeScale::UTC => Self::from_utc_duration(self.to_utc_duration().ceil(duration)),
             TimeScale::ET => Self::from_et_duration(self.to_et_duration().ceil(duration)),
             TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().ceil(duration)),
             TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().ceil(duration)),
-            TimeScale::GPST => Self::from_gpst_duration(self.to_gpst_duration().ceil(duration)),
-            TimeScale::GST => Self::from_gst_duration(self.to_gst_duration().ceil(duration)),
-            TimeScale::BDT => Self::from_bdt_duration(self.to_bdt_duration().ceil(duration)),
+            ts => Self::from_duration(self.to_duration().ceil(duration), ts),
         }
     }
 
@@ -2145,13 +2139,10 @@ impl Epoch {
             TimeScale::TAI => {
                 Self::from_tai_duration(self.duration_since_j1900_tai.round(duration))
             }
-            TimeScale::UTC => Self::from_utc_duration(self.to_utc_duration().round(duration)),
             TimeScale::ET => Self::from_et_duration(self.to_et_duration().round(duration)),
             TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().round(duration)),
             TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().round(duration)),
-            TimeScale::GPST => Self::from_gpst_duration(self.to_gpst_duration().round(duration)),
-            TimeScale::GST => Self::from_gst_duration(self.to_gst_duration().round(duration)),
-            TimeScale::BDT => Self::from_bdt_duration(self.to_bdt_duration().round(duration)),
+            ts => Self::from_duration(self.to_duration().round(duration), ts),
         }
     }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1313,7 +1313,7 @@ impl Epoch {
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the Galileo Time Epoch,
     /// defined as 13 seconds prior UTC midnight August 22nd 1999 
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_seconds(seconds: f64) -> Self {
         Self::from_gst_seconds(seconds)
     }
@@ -1322,7 +1322,7 @@ impl Epoch {
     #[staticmethod]
     /// Initialize an Epoch from the number of days since the Galileo Time Epoch,
     /// defined as 13 seconds prior UTC midnight August 22nd 1999 
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     fn init_from_gst_days(days: f64) -> Self {
         Self::from_gst_days(days)
     }
@@ -1331,10 +1331,35 @@ impl Epoch {
     #[staticmethod]
     /// Initialize an Epoch from the number of nanoseconds since the Galileo Time Epoch,
     /// defined as 13 seconds prior UTC midnight August 22nd 1999 
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// This may be useful for time keeping devices that use GST as a time source.
     fn init_from_gst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_gst_nanoseconds(nanoseconds)
+    }
+    
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    /// Initialize an Epoch from the number of seconds since the BeiDou Time Epoch,
+    /// defined as January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    fn init_from_bdt_seconds(seconds: f64) -> Self {
+        Self::from_bdt_seconds(seconds)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    /// Initialize an Epoch from the number of days since the BeiDou Time Epoch,
+    /// defined as January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    fn init_from_bdt_days(days: f64) -> Self {
+        Self::from_bdt_days(days)
+    }
+
+    #[cfg(feature = "python")]
+    #[staticmethod]
+    /// Initialize an Epoch from the number of days since the BeiDou Time Epoch,
+    /// defined as January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    /// This may be useful for time keeping devices that use BDT as a time source.
+    fn init_from_bdt_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_bdt_nanoseconds(nanoseconds)
     }
 
     #[cfg(feature = "python")]

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -11,9 +11,9 @@
 use crate::duration::{Duration, Unit};
 use crate::parser::Token;
 use crate::{
-    Errors, TimeScale, DAYS_PER_YEAR_NLD, ET_EPOCH_S, J1900_OFFSET,
-    J2000_TO_J1900_DURATION, MJD_OFFSET, NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND,
-    NANOSECONDS_PER_SECOND_U32, UNIX_REF_EPOCH,
+    Errors, TimeScale, BDT_REF_EPOCH, DAYS_PER_YEAR_NLD, ET_EPOCH_S, GPST_REF_EPOCH, GST_REF_EPOCH,
+    J1900_OFFSET, J2000_TO_J1900_DURATION, MJD_OFFSET, NANOSECONDS_PER_MICROSECOND,
+    NANOSECONDS_PER_MILLISECOND, NANOSECONDS_PER_SECOND_U32, UNIX_REF_EPOCH,
 };
 use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::fmt;
@@ -276,18 +276,10 @@ impl Epoch {
             TimeScale::TT => Self::from_tt_duration(new_duration),
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
-            ts => {
-                // epoch is always referenced to TAI J1900    
-                let mut e = Self::from_tai_duration(new_duration);
-                if ts.uses_leap() {
-                    e.duration_since_j1900_tai += e.leap_seconds(true)
-                        .unwrap_or(0.0) * Unit::Second;
-                }
-                let ts_offset = ts.tai_j1900_offset_seconds_i64();
-                e.duration_since_j1900_tai += Duration::from_f64(ts_offset as f64, Unit::Second);
-                e.time_scale = ts;
-                e
-            },
+            TimeScale::UTC => Self::from_utc_duration(new_duration),
+            TimeScale::GPST => Self::from_gpst_duration(new_duration),
+            TimeScale::GST => Self::from_gst_duration(new_duration),
+            TimeScale::BDT => Self::from_bdt_duration(new_duration),
         }
     }
 
@@ -329,7 +321,14 @@ impl Epoch {
     #[must_use]
     /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
     pub fn from_utc_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::UTC)
+        let mut e = Self::from_tai_duration(duration);
+        // Compute the TAI to UTC offset at this time.
+        // We have the time in TAI. But we were given UTC.
+        // Hence, we need to _add_ the leap seconds to get the actual TAI time.
+        // TAI = UTC + leap_seconds <=> UTC = TAI - leap_seconds
+        e.duration_since_j1900_tai += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
+        e.time_scale = TimeScale::UTC;
+        e
     }
 
     #[must_use]
@@ -345,21 +344,27 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight 
+    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
     pub fn from_gpst_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::GPST)
+        let mut me = Self::from_tai_duration(GPST_REF_EPOCH.to_tai_duration() + duration);
+        me.time_scale = TimeScale::GPST;
+        me
     }
-    
+
     #[must_use]
     /// Initialize an Epoch from the provided duration since August 21st 1999 midnight
     pub fn from_gst_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::GST)
+        let mut me = Self::from_tai_duration(GST_REF_EPOCH.to_tai_duration() + duration);
+        me.time_scale = TimeScale::GST;
+        me
     }
 
     #[must_use]
     /// Initialize an Epoch from the provided duration since January 1st midnight
     pub fn from_bdt_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::BDT)
+        let mut me = Self::from_utc_duration(BDT_REF_EPOCH.to_utc_duration() + duration);
+        me.time_scale = TimeScale::BDT;
+        me
     }
 
     #[must_use]
@@ -370,11 +375,11 @@ impl Epoch {
         );
         Self::from_tai_duration((days - J1900_OFFSET) * Unit::Day)
     }
-    
-    fn from_mjd_ts(days: f64, ts: TimeScale) -> Self {
+
+    fn from_mjd_in_time_scale(days: f64, ts: TimeScale) -> Self {
         // always refer to TAI/mjd
         let mut e = Self::from_mjd_tai(days);
-        if ts.uses_leap() {
+        if ts.uses_leap_seconds() {
             e.duration_since_j1900_tai += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
         }
         e.time_scale = ts;
@@ -383,19 +388,19 @@ impl Epoch {
 
     #[must_use]
     pub fn from_mjd_utc(days: f64) -> Self {
-        Self::from_mjd_ts(days, TimeScale::UTC)
+        Self::from_mjd_in_time_scale(days, TimeScale::UTC)
     }
     #[must_use]
     pub fn from_mjd_gpst(days: f64) -> Self {
-        Self::from_mjd_ts(days, TimeScale::GPST)
+        Self::from_mjd_in_time_scale(days, TimeScale::GPST)
     }
     #[must_use]
     pub fn from_mjd_gst(days: f64) -> Self {
-        Self::from_mjd_ts(days, TimeScale::GST)
+        Self::from_mjd_in_time_scale(days, TimeScale::GST)
     }
     #[must_use]
     pub fn from_mjd_bdt(days: f64) -> Self {
-        Self::from_mjd_ts(days, TimeScale::BDT)
+        Self::from_mjd_in_time_scale(days, TimeScale::BDT)
     }
 
     #[must_use]
@@ -407,10 +412,10 @@ impl Epoch {
         Self::from_tai_duration((days - J1900_OFFSET - MJD_OFFSET) * Unit::Day)
     }
 
-    fn from_jde_ts(days: f64, ts: TimeScale) -> Self {
+    fn from_jde_in_time_scale(days: f64, ts: TimeScale) -> Self {
         // always refer to TAI/jde
         let mut e = Self::from_jde_tai(days);
-        if ts.uses_leap() {
+        if ts.uses_leap_seconds() {
             e.duration_since_j1900_tai += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
         }
         e.time_scale = ts;
@@ -419,19 +424,19 @@ impl Epoch {
 
     #[must_use]
     pub fn from_jde_utc(days: f64) -> Self {
-        Self::from_jde_ts(days, TimeScale::UTC)
+        Self::from_jde_in_time_scale(days, TimeScale::UTC)
     }
     #[must_use]
     pub fn from_jde_gpst(days: f64) -> Self {
-        Self::from_jde_ts(days, TimeScale::GPST)
+        Self::from_jde_in_time_scale(days, TimeScale::GPST)
     }
     #[must_use]
     pub fn from_jde_gst(days: f64) -> Self {
-        Self::from_jde_ts(days, TimeScale::GST)
+        Self::from_jde_in_time_scale(days, TimeScale::GST)
     }
     #[must_use]
     pub fn from_jde_bdt(days: f64) -> Self {
-        Self::from_jde_ts(days, TimeScale::BDT)
+        Self::from_jde_in_time_scale(days, TimeScale::BDT)
     }
 
     #[must_use]
@@ -550,7 +555,7 @@ impl Epoch {
     pub fn from_gpst_seconds(seconds: f64) -> Self {
         Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::GPST)
     }
-    
+
     #[must_use]
     /// Initialize an Epoch from the number of days since the GPS Time Epoch,
     /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
@@ -563,9 +568,12 @@ impl Epoch {
     /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
     /// This may be useful for time keeping devices that use GPS as a time source.
     pub fn from_gpst_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_f64(nanoseconds as f64, Unit::Nanosecond), TimeScale::GPST)
+        Self::from_duration(
+            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            TimeScale::GPST,
+        )
     }
-    
+
     #[must_use]
     /// Initialize an Epoch from the number of seconds since the GST Time Epoch,
     /// starting August 21st 1999 midnight (UTC)
@@ -573,7 +581,7 @@ impl Epoch {
     pub fn from_gst_seconds(seconds: f64) -> Self {
         Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::GST)
     }
-    
+
     #[must_use]
     /// Initialize an Epoch from the number of days since the GST Time Epoch,
     /// starting August 21st 1999 midnight (UTC)
@@ -587,7 +595,10 @@ impl Epoch {
     /// starting August 21st 1999 midnight (UTC)
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_f64(nanoseconds as f64, Unit::Nanosecond), TimeScale::GST)
+        Self::from_duration(
+            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            TimeScale::GST,
+        )
     }
 
     #[must_use]
@@ -596,7 +607,7 @@ impl Epoch {
     pub fn from_bdt_seconds(seconds: f64) -> Self {
         Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::BDT)
     }
-    
+
     #[must_use]
     /// Initialize an Epoch from the number of days since the BDT Time Epoch,
     /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
@@ -609,21 +620,22 @@ impl Epoch {
     /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// This may be useful for time keeping devices that use BDT as a time source.
     pub fn from_bdt_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_f64(nanoseconds as f64, Unit::Nanosecond), TimeScale::BDT)
+        Self::from_duration(
+            Duration::from_f64(nanoseconds as f64, Unit::Nanosecond),
+            TimeScale::BDT,
+        )
     }
 
     #[must_use]
     /// Initialize an Epoch from the provided UNIX second timestamp since UTC midnight 1970 January 01.
     pub fn from_unix_seconds(seconds: f64) -> Self {
-        let utc_seconds = UNIX_REF_EPOCH.to_utc_duration() + seconds * Unit::Second;
-        Self::from_utc_seconds(utc_seconds.to_unit(Unit::Second))
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + seconds * Unit::Second)
     }
 
     #[must_use]
     /// Initialize an Epoch from the provided UNIX milisecond timestamp since UTC midnight 1970 January 01.
     pub fn from_unix_milliseconds(millisecond: f64) -> Self {
-        let utc_seconds = UNIX_REF_EPOCH.to_utc_duration() + millisecond * Unit::Millisecond;
-        Self::from_utc_seconds(utc_seconds.to_unit(Unit::Second))
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + millisecond * Unit::Millisecond)
     }
 
     /// Attempts to build an Epoch from the provided Gregorian date and time in TAI.
@@ -711,7 +723,10 @@ impl Epoch {
             TimeScale::TT => Self::from_tt_duration(duration_wrt_1900),
             TimeScale::ET => Self::from_et_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::TDB => Self::from_tdb_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
-            ts => Self::from_duration(duration_wrt_1900, ts),
+            TimeScale::UTC => Self::from_utc_duration(duration_wrt_1900),
+            TimeScale::GPST => Self::from_gpst_duration(duration_wrt_1900),
+            TimeScale::GST => Self::from_gst_duration(duration_wrt_1900),
+            TimeScale::BDT => Self::from_bdt_duration(duration_wrt_1900),
         })
     }
 
@@ -1268,7 +1283,7 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    /// Initialize an Epoch from the Ephemeris Time duration past 2000 JAN 01 (J2000 reference) 
+    /// Initialize an Epoch from the Ephemeris Time duration past 2000 JAN 01 (J2000 reference)
     fn init_from_et_duration(duration_since_j2000: Duration) -> Self {
         Self::from_et_duration(duration_since_j2000)
     }
@@ -1327,7 +1342,7 @@ impl Epoch {
     fn init_from_gpst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_gpst_nanoseconds(nanoseconds)
     }
-    
+
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the Galileo Time Epoch,
@@ -1355,7 +1370,7 @@ impl Epoch {
     fn init_from_gst_nanoseconds(nanoseconds: u64) -> Self {
         Self::from_gst_nanoseconds(nanoseconds)
     }
-    
+
     #[cfg(feature = "python")]
     #[staticmethod]
     /// Initialize an Epoch from the number of seconds since the BeiDou Time Epoch,
@@ -1574,26 +1589,23 @@ impl Epoch {
     /// This is needed to correctly perform duration conversions in dynamical time scales (e.g. TDB).
     pub fn to_duration_in_time_scale(&self, time_scale: TimeScale) -> Duration {
         match time_scale {
-            TimeScale::ET => self.to_et_duration(),
             TimeScale::TAI => self.duration_since_j1900_tai,
             TimeScale::TT => self.to_tt_duration(),
+            TimeScale::ET => self.to_et_duration(),
             TimeScale::TDB => self.to_tdb_duration(),
-            ts => self.to_ts_duration(ts),
+            TimeScale::UTC => self.to_utc_duration(),
+            TimeScale::GPST => self.to_gpst_duration(),
+            TimeScale::BDT => self.to_bdt_duration(),
+            TimeScale::GST => self.to_gst_duration(),
         }
     }
 
-    fn to_ts_duration(&self, ts: TimeScale) -> Duration {
-        let mut duration = self.duration_since_j1900_tai;
-        if ts.uses_leap() {
-            duration -= self.leap_seconds(true)
-                .unwrap_or(0.0) * Unit::Second;
-        }
-        duration -= ts.tai_j1900_offset_seconds_i64() * Unit::Second;
-        duration
-    }
-
-    fn to_ts_nanoseconds(&self, ts: TimeScale) -> Result<u64, Errors> {
-        let (centuries, nanoseconds) = self.to_ts_duration(ts).to_parts();
+    /// Attempts to return the number of nanoseconds since the reference epoch of the provided time scale.
+    /// This will return an overflow error if more than one century has past since the reference epoch in the provided time scale.
+    /// If this is _not_ an issue, you should use `epoch.to_duration_in_time_scale().to_parts()` to retrieve both the centuries and the nanoseconds
+    /// in that century.
+    fn to_nanoseconds_in_time_scale(&self, ts: TimeScale) -> Result<u64, Errors> {
+        let (centuries, nanoseconds) = self.to_duration_in_time_scale(ts).to_parts();
         if centuries != 0 {
             Err(Errors::Overflow)
         } else {
@@ -1615,7 +1627,10 @@ impl Epoch {
             TimeScale::TAI => self.duration_since_j1900_tai,
             TimeScale::TT => self.to_tt_duration(),
             TimeScale::TDB => self.to_tdb_duration_since_j1900(),
-            ts => self.to_ts_duration(ts),
+            TimeScale::UTC => self.to_utc_duration(),
+            TimeScale::GPST => self.to_gpst_duration() - GPST_REF_EPOCH.to_tai_duration(),
+            TimeScale::GST => self.to_gst_duration() + GST_REF_EPOCH.to_tai_duration(),
+            TimeScale::BDT => self.to_bdt_duration() + BDT_REF_EPOCH.to_utc_duration(),
         }
     }
 
@@ -1627,7 +1642,10 @@ impl Epoch {
             TimeScale::TT => Self::from_tt_duration(new_duration),
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
-            ts => Self::from_duration(new_duration, ts),
+            TimeScale::UTC => Self::from_utc_duration(new_duration),
+            TimeScale::GPST => Self::from_gpst_duration(new_duration),
+            TimeScale::GST => Self::from_gst_duration(new_duration),
+            TimeScale::BDT => Self::from_bdt_duration(new_duration),
         }
     }
 
@@ -1670,7 +1688,8 @@ impl Epoch {
     #[must_use]
     /// Returns this time in a Duration past J1900 counted in UTC
     pub fn to_utc_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::UTC)
+        // TAI = UTC + leap_seconds <=> UTC = TAI - leap_seconds
+        self.duration_since_j1900_tai - self.leap_seconds(true).unwrap_or(0.0) * Unit::Second
     }
 
     #[must_use]
@@ -1827,13 +1846,13 @@ impl Epoch {
     #[must_use]
     /// Returns `Duration` past GPS time Epoch.
     pub fn to_gpst_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::GPST)
+        self.duration_since_j1900_tai - GPST_REF_EPOCH.to_tai_duration()
     }
-    
+
     /// Returns nanoseconds past GPS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
     /// NOTE: This function will return an error if the centuries past GPST time are not zero.
     pub fn to_gpst_nanoseconds(&self) -> Result<u64, Errors> {
-        self.to_ts_nanoseconds(TimeScale::GPST)
+        self.to_nanoseconds_in_time_scale(TimeScale::GPST)
     }
 
     #[must_use]
@@ -1841,7 +1860,7 @@ impl Epoch {
     pub fn to_gpst_days(&self) -> f64 {
         self.to_gpst_duration().to_unit(Unit::Day)
     }
-    
+
     #[must_use]
     /// Returns seconds past GST (Galileo) Time Epoch
     pub fn to_gst_seconds(&self) -> f64 {
@@ -1851,9 +1870,9 @@ impl Epoch {
     #[must_use]
     /// Returns `Duration` past GST (Galileo) time Epoch.
     pub fn to_gst_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::GST)
+        self.duration_since_j1900_tai - GST_REF_EPOCH.to_tai_duration()
     }
-    
+
     #[must_use]
     /// Returns days past GST (Galileo) Time Epoch,
     /// starting on August 21st 1999 Midnight UTC
@@ -1861,15 +1880,14 @@ impl Epoch {
     pub fn to_gst_days(&self) -> f64 {
         self.to_gst_duration().to_unit(Unit::Day)
     }
-    
-    /// Returns nanoseconds past GST (Galileo) Time Epoch, 
-    /// starting on August 21st 1999 Midnight UTC
+
+    /// Returns nanoseconds past GST (Galileo) Time Epoch, starting on August 21st 1999 Midnight UTC
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// NOTE: This function will return an error if the centuries past GST time are not zero.
     pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {
-        self.to_ts_nanoseconds(TimeScale::GST)
+        self.to_nanoseconds_in_time_scale(TimeScale::GST)
     }
-    
+
     #[must_use]
     /// Returns seconds past BDT (BeiDou) Time Epoch
     pub fn to_bdt_seconds(&self) -> f64 {
@@ -1879,7 +1897,7 @@ impl Epoch {
     #[must_use]
     /// Returns `Duration` past BDT (BeiDou) time Epoch.
     pub fn to_bdt_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::BDT)
+        self.to_utc_duration() - BDT_REF_EPOCH.to_utc_duration()
     }
 
     #[must_use]
@@ -1893,17 +1911,14 @@ impl Epoch {
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// NOTE: This function will return an error if the centuries past GST time are not zero.
     pub fn to_bdt_nanoseconds(&self) -> Result<u64, Errors> {
-        self.to_ts_nanoseconds(TimeScale::BDT)
+        self.to_nanoseconds_in_time_scale(TimeScale::BDT)
     }
 
     #[allow(clippy::wrong_self_convention)]
     #[must_use]
-    ///Returns the Duration since the UNIX epoch UTC midnight 01 Jan 1970.
+    /// Returns the Duration since the UNIX epoch UTC midnight 01 Jan 1970.
     fn to_unix_duration(&self) -> Duration {
-        // TAI = UNIX + leap_seconds + UNIX_OFFSET_UTC_SECONDS <=> UNIX = TAI - leap_seconds - UNIX_OFFSET_UTC_SECONDS
-        self.duration_since_j1900_tai
-            - self.leap_seconds(true).unwrap_or(0.0) * Unit::Second
-            - UNIX_REF_EPOCH.to_utc_duration()
+        self.to_duration_in_time_scale(TimeScale::UTC) - UNIX_REF_EPOCH.to_utc_duration()
     }
 
     #[must_use]
@@ -2138,15 +2153,7 @@ impl Epoch {
     /// );
     /// ```
     pub fn floor(&self, duration: Duration) -> Self {
-        match self.time_scale {
-            TimeScale::TAI => {
-                Self::from_tai_duration(self.duration_since_j1900_tai.floor(duration))
-            }
-            TimeScale::ET => Self::from_et_duration(self.to_et_duration().floor(duration)),
-            TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().floor(duration)),
-            TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().floor(duration)),
-            ts => Self::from_duration(self.to_duration().floor(duration), ts),
-        }
+        Self::from_duration(self.to_duration().floor(duration), self.time_scale)
     }
 
     /// Ceils this epoch to the closest provided duration in the TAI time system
@@ -2169,13 +2176,7 @@ impl Epoch {
     /// );
     /// ```
     pub fn ceil(&self, duration: Duration) -> Self {
-        match self.time_scale {
-            TimeScale::TAI => Self::from_tai_duration(self.duration_since_j1900_tai.ceil(duration)),
-            TimeScale::ET => Self::from_et_duration(self.to_et_duration().ceil(duration)),
-            TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().ceil(duration)),
-            TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().ceil(duration)),
-            ts => Self::from_duration(self.to_duration().ceil(duration), ts),
-        }
+        Self::from_duration(self.to_duration().ceil(duration), self.time_scale)
     }
 
     /// Rounds this epoch to the closest provided duration in TAI
@@ -2191,15 +2192,7 @@ impl Epoch {
     /// );
     /// ```
     pub fn round(&self, duration: Duration) -> Self {
-        match self.time_scale {
-            TimeScale::TAI => {
-                Self::from_tai_duration(self.duration_since_j1900_tai.round(duration))
-            }
-            TimeScale::ET => Self::from_et_duration(self.to_et_duration().round(duration)),
-            TimeScale::TDB => Self::from_tdb_duration(self.to_tdb_duration().round(duration)),
-            TimeScale::TT => Self::from_tt_duration(self.to_tt_duration().round(duration)),
-            ts => Self::from_duration(self.to_duration().round(duration), ts),
-        }
+        Self::from_duration(self.to_duration().round(duration), self.time_scale)
     }
 
     /// Copies this epoch and sets it to the new time scale provided.
@@ -2440,7 +2433,9 @@ impl FromStr for Epoch {
                 },
                 "MJD" => match ts {
                     TimeScale::TAI => Ok(Self::from_mjd_tai(value)),
-                    TimeScale::UTC | TimeScale::GPST | TimeScale::BDT | TimeScale::GST => Ok(Self::from_mjd_ts(value, ts)),
+                    TimeScale::UTC | TimeScale::GPST | TimeScale::BDT | TimeScale::GST => {
+                        Ok(Self::from_mjd_in_time_scale(value, ts))
+                    }
                     _ => Err(Errors::ParseError(ParsingErrors::UnsupportedTimeSystem)),
                 },
                 "SEC" => match ts {
@@ -2451,7 +2446,7 @@ impl FromStr for Epoch {
                     ts => {
                         let secs = Duration::from_f64(value, Unit::Second);
                         Ok(Self::from_duration(secs, ts))
-                    },
+                    }
                 },
                 _ => Err(Errors::ParseError(ParsingErrors::UnknownFormat)),
             }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -711,10 +711,7 @@ impl Epoch {
             TimeScale::TT => Self::from_tt_duration(duration_wrt_1900),
             TimeScale::ET => Self::from_et_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::TDB => Self::from_tdb_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
-            TimeScale::UTC => Self::from_utc_duration(duration_wrt_1900),
-            TimeScale::GPST => Self::from_gpst_duration(duration_wrt_1900),
-            TimeScale::GST => Self::from_gst_duration(duration_wrt_1900),
-            TimeScale::BDT => Self::from_bdt_duration(duration_wrt_1900),
+            ts => Self::from_duration(duration_wrt_1900, ts),
         })
     }
 
@@ -1625,10 +1622,7 @@ impl Epoch {
             TimeScale::TT => Self::from_tt_duration(new_duration),
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
-            TimeScale::UTC => Self::from_utc_duration(new_duration),
-            TimeScale::GPST => Self::from_gpst_duration(new_duration),
-            TimeScale::GST => Self::from_gst_duration(new_duration),
-            TimeScale::BDT => Self::from_bdt_duration(new_duration),
+            ts => Self::from_duration(new_duration, ts),
         }
     }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -356,7 +356,7 @@ impl Epoch {
     #[must_use]
     /// Initialize an Epoch from the provided duration since 1980 January 6 13 seconds prior midnight 
     pub fn from_gst_duration(duration: Duration) -> Self {
-        let mut e = Self::from_tai_duration(duration) + Unit::Second + SECONDS_GST_TAI_OFFSET;
+        let mut e = Self::from_tai_duration(duration) + Unit::Second * SECONDS_GST_TAI_OFFSET;
         e.time_scale = TimeScale::GPST;
         e
     }
@@ -364,7 +364,7 @@ impl Epoch {
     #[must_use]
     /// Initialize an Epoch from the provided duration since January 1st midnight
     pub fn from_bdt_duration(duration: Duration) -> Self {
-        let mut e = Self::from_tai_duration(duration) + Unit::Second + SECONDS_BDT_TAI_OFFSET;
+        let mut e = Self::from_tai_duration(duration) + Unit::Second * SECONDS_BDT_TAI_OFFSET;
         e.time_scale = TimeScale::BDT;
         e
     }
@@ -543,22 +543,24 @@ impl Epoch {
     
     #[must_use]
     /// Initialize an Epoch from the number of seconds since the GST Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_seconds(seconds: f64) -> Self {
         Self::from_tai_seconds(seconds) + Unit::Second * SECONDS_GPS_TAI_OFFSET
     }
     
     #[must_use]
     /// Initialize an Epoch from the number of days since the GST Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_days(days: f64) -> Self {
         Self::from_tai_days(days) + Unit::Day * DAYS_GST_TAI_OFFSET
     }
 
     #[must_use]
     /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
-    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    /// This may be useful for time keeping devices that use GST as a time source.
+    /// defined as 13 seconds before UTC midnight on Sunday 22nd 1999 
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
         let duration = Duration::from_parts(0, nanoseconds) + Unit::Second * SECONDS_GST_TAI_OFFSET;
         Self {
@@ -569,21 +571,21 @@ impl Epoch {
 
     #[must_use]
     /// Initialize an Epoch from the number of seconds since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_bdt_seconds(seconds: f64) -> Self {
         Self::from_tai_seconds(seconds) + Unit::Second * SECONDS_BDT_TAI_OFFSET
     }
     
     #[must_use]
     /// Initialize an Epoch from the number of days since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
     pub fn from_bdt_days(days: f64) -> Self {
         Self::from_tai_days(days) + Unit::Day * DAYS_BDT_TAI_OFFSET
     }
 
     #[must_use]
     /// Initialize an Epoch from the number of nanoseconds since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     /// This may be useful for time keeping devices that use BDT as a time source.
     pub fn from_bdt_nanoseconds(nanoseconds: u64) -> Self {
         let duration = Duration::from_parts(0, nanoseconds) + Unit::Second * SECONDS_BDT_TAI_OFFSET;

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1219,24 +1219,28 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    /// Initialize an Epoch from given MJD in TAI time scale
     fn init_from_mjd_tai(days: f64) -> Self {
         Self::from_mjd_tai(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    /// Initialize an Epoch from given MJD in UTC time scale
     fn init_from_mjd_utc(days: f64) -> Self {
         Self::from_mjd_utc(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    /// Initialize an Epoch from given JDE in TAI time scale
     fn init_from_jde_tai(days: f64) -> Self {
         Self::from_jde_tai(days)
     }
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    /// Initialize an Epoch from given JDE in UTC time scale
     fn init_from_jde_utc(days: f64) -> Self {
         Self::from_jde_utc(days)
     }
@@ -1264,6 +1268,7 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
+    /// Initialize an Epoch from the Ephemeris Time duration past 2000 JAN 01 (J2000 reference) 
     fn init_from_et_duration(duration_since_j2000: Duration) -> Self {
         Self::from_et_duration(duration_since_j2000)
     }
@@ -1726,11 +1731,13 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Returns the Julian Days from epoch 01 Jan -4713 12:00 (noon) in desired Duration::Unit
     pub fn to_jde_tai(&self, unit: Unit) -> f64 {
         self.to_jde_tai_duration().to_unit(unit)
     }
 
     #[must_use]
+    /// Returns the Julian Days from epoch 01 Jan -4713 12:00 (noon) as a Duration
     pub fn to_jde_tai_duration(&self) -> Duration {
         self.duration_since_j1900_tai + Unit::Day * J1900_OFFSET + Unit::Day * MJD_OFFSET
     }
@@ -1748,12 +1755,13 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Returns the Julian days in UTC as a `Duration`
     pub fn to_jde_utc_duration(&self) -> Duration {
         self.to_utc_duration() + Unit::Day * (J1900_OFFSET + MJD_OFFSET)
     }
 
     #[must_use]
-    /// Returns the Julian seconds in UTC.
+    /// Returns the Julian Days in UTC seconds.
     pub fn to_jde_utc_seconds(&self) -> f64 {
         self.to_jde_utc_duration().to_seconds()
     }
@@ -1765,6 +1773,7 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Returns `Duration` past TAI epoch in Terrestrial Time (TT).
     pub fn to_tt_duration(&self) -> Duration {
         self.duration_since_j1900_tai + Unit::Millisecond * TT_OFFSET_MS
     }
@@ -1816,18 +1825,11 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Returns `Duration` past GPS time Epoch.
     pub fn to_gpst_duration(&self) -> Duration {
         self.to_ts_duration(TimeScale::GPST)
     }
-    #[must_use]
-    pub fn to_gst_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::GST)
-    }
-    #[must_use]
-    pub fn to_bdt_duration(&self) -> Duration {
-        self.to_ts_duration(TimeScale::BDT)
-    }
-
+    
     /// Returns nanoseconds past GPS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
     /// NOTE: This function will return an error if the centuries past GPST time are not zero.
     pub fn to_gpst_nanoseconds(&self) -> Result<u64, Errors> {
@@ -1838,6 +1840,46 @@ impl Epoch {
     /// Returns days past GPS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
     pub fn to_gpst_days(&self) -> f64 {
         self.to_gpst_duration().to_unit(Unit::Day)
+    }
+    
+    #[must_use]
+    /// Returns `Duration` past GST (Galileo) time Epoch.
+    pub fn to_gst_duration(&self) -> Duration {
+        self.to_ts_duration(TimeScale::GST)
+    }
+    
+    #[must_use]
+    /// Returns days past GST (Galileo) Time Epoch, defined as 13 seconds prior midnight, August 22nd 1999 UTC
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    pub fn to_gst_days(&self) -> f64 {
+        self.to_gst_duration().to_unit(Unit::Day)
+    }
+    
+    /// Returns nanoseconds past GST (Galileo) Time Epoch, defined as 13 seconds prior midnight, August 22nd 1999 UTC,
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    /// NOTE: This function will return an error if the centuries past GST time are not zero.
+    pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {
+        self.to_ts_nanoseconds(TimeScale::GST)
+    }
+    
+    #[must_use]
+    /// Returns `Duration` past BDT (BeiDou) time Epoch.
+    pub fn to_bdt_duration(&self) -> Duration {
+        self.to_ts_duration(TimeScale::BDT)
+    }
+
+    #[must_use]
+    /// Returns days past BDT (BeiDou) Time Epoch, defined as Jan 01 2006 UTC
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    pub fn to_bdt_days(&self) -> f64 {
+        self.to_bdt_duration().to_unit(Unit::Day)
+    }
+
+    /// Returns nanoseconds past BDT (BeiDou) Time Epoch, defined as Jan 01 2006 UTC
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    /// NOTE: This function will return an error if the centuries past GST time are not zero.
+    pub fn to_bdt_nanoseconds(&self) -> Result<u64, Errors> {
+        self.to_ts_nanoseconds(TimeScale::BDT)
     }
 
     #[allow(clippy::wrong_self_convention)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,21 @@ pub const SECONDS_GPS_TAI_OFFSET_I64: i64 =
 /// `DAYS_GPS_TAI_OFFSET` is the number of days from the TAI epoch to the GPS
 /// epoch (UTC midnight of January 6th 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
 pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
-
+/// `SECONDS_GST_TAI_OFFSET` is the number of seconds from the TAI epoch to the
+/// GST epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+pub const SECONDS_GST_TAI_OFFSET: f64 = 99.0 * SECONDS_PER_YEAR + 21.0 * SECONDS_PER_DAY - 13.0;
+pub const SECONDS_GST_TAI_OFFSET_I64: i64 =
+    99 * SECONDS_PER_YEAR_I64 + 21 * SECONDS_PER_DAY_I64 - 13;
+/// `DAYS_GST_TAI_OFFSET` is the number of days from the TAI epoch to the GST
+/// epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+pub const DAYS_GST_TAI_OFFSET: f64 = SECONDS_GST_TAI_OFFSET / SECONDS_PER_DAY;
+/// `SECONDS_BDT_TAI_OFFSET` is the number of seconds from the TAI epoch to the
+/// BDT epoch (UTC midnight January 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+pub const SECONDS_BDT_TAI_OFFSET: f64 = 106.0 * SECONDS_PER_YEAR;
+pub const SECONDS_BDT_TAI_OFFSET_I64: i64 = 106 * SECONDS_PER_YEAR_I64;
+/// `DAYS_BDT_TAI_OFFSET` is the number of days from the TAI epoch to the BDT
+/// epoch (UTC midnight Jan 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+pub const DAYS_BDT_TAI_OFFSET: f64 = SECONDS_BDT_TAI_OFFSET / SECONDS_PER_DAY;
 /// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
 pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
     centuries: 0,
@@ -193,7 +207,7 @@ fn test_ts() {
         let ts = TimeScale::from(ts_u8);
         let ts_u8_back: u8 = ts.into();
         // If the u8 is greater than 5, it isn't valid and necessarily encoded as TAI.
-        if ts_u8 < 5 {
+        if ts_u8 < 8 {
             assert_eq!(ts_u8_back, ts_u8, "got {ts_u8_back} want {ts_u8}");
         } else {
             assert_eq!(ts, TimeScale::TAI);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,16 +53,11 @@ pub const SECONDS_PER_YEAR_I64: i64 = 31_557_600;
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
 /// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sideral year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
 pub const SECONDS_PER_SIDERAL_YEAR: f64 = 31_558_150.0;
-/// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
-pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
-    centuries: 0,
-    nanoseconds: 2_208_988_800_000_000_000,
-});
 
-/// The duration between J2000 and J1900: one century **minus** twelve hours. J1900 starts at  _noon_ but J2000 is at midnight.
+/// The duration between J2000 and J1900: one century **minus** twelve hours. J1900 starts at _noon_ but J2000 is at midnight.
 pub const J2000_TO_J1900_DURATION: Duration = Duration {
     centuries: 0,
-    nanoseconds: 3155716800000000000,
+    nanoseconds: 3_155_716_800_000_000_000,
 };
 
 mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,18 +63,18 @@ pub const SECONDS_GPS_TAI_OFFSET_I64: i64 =
 pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
 /// `SECONDS_GST_TAI_OFFSET` is the number of seconds from the TAI epoch to the
 /// GST epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
-pub const SECONDS_GST_TAI_OFFSET: f64 = 99.0 * SECONDS_PER_YEAR + 21.0 * SECONDS_PER_DAY - 13.0;
+pub const SECONDS_GST_TAI_OFFSET: f64 = 99.0 * SECONDS_PER_DAY - 13.0; // missing 22nd of august offset
 pub const SECONDS_GST_TAI_OFFSET_I64: i64 =
-    99 * SECONDS_PER_YEAR_I64 + 21 * SECONDS_PER_DAY_I64 - 13;
+    99 * SECONDS_PER_YEAR_I64 - 13; // missing 22nd of august offset
 /// `DAYS_GST_TAI_OFFSET` is the number of days from the TAI epoch to the GST
 /// epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
 pub const DAYS_GST_TAI_OFFSET: f64 = SECONDS_GST_TAI_OFFSET / SECONDS_PER_DAY;
 /// `SECONDS_BDT_TAI_OFFSET` is the number of seconds from the TAI epoch to the
-/// BDT epoch (UTC midnight January 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+/// BDT epoch (UTC midnight January 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
 pub const SECONDS_BDT_TAI_OFFSET: f64 = 106.0 * SECONDS_PER_YEAR;
 pub const SECONDS_BDT_TAI_OFFSET_I64: i64 = 106 * SECONDS_PER_YEAR_I64;
 /// `DAYS_BDT_TAI_OFFSET` is the number of days from the TAI epoch to the BDT
-/// epoch (UTC midnight Jan 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
+/// epoch (UTC midnight Jan 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
 pub const DAYS_BDT_TAI_OFFSET: f64 = SECONDS_BDT_TAI_OFFSET / SECONDS_PER_DAY;
 /// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
 pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,29 +53,6 @@ pub const SECONDS_PER_YEAR_I64: i64 = 31_557_600;
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
 /// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sideral year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
 pub const SECONDS_PER_SIDERAL_YEAR: f64 = 31_558_150.0;
-/// `SECONDS_GPS_TAI_OFFSET` is the number of seconds from the TAI epoch to the
-/// GPS epoch (UTC midnight of January 6th 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
-pub const SECONDS_GPS_TAI_OFFSET: f64 = 80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
-pub const SECONDS_GPS_TAI_OFFSET_I64: i64 =
-    80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
-/// `DAYS_GPS_TAI_OFFSET` is the number of days from the TAI epoch to the GPS
-/// epoch (UTC midnight of January 6th 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
-pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
-/// `SECONDS_GST_TAI_OFFSET` is the number of seconds from the TAI epoch to the
-/// GST epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
-pub const SECONDS_GST_TAI_OFFSET: f64 = 99.0 * SECONDS_PER_DAY - 13.0; // missing 22nd of august offset
-pub const SECONDS_GST_TAI_OFFSET_I64: i64 =
-    99 * SECONDS_PER_YEAR_I64 - 13; // missing 22nd of august offset
-/// `DAYS_GST_TAI_OFFSET` is the number of days from the TAI epoch to the GST
-/// epoch (UTC midnight - 13 seconds of Sunday August 22d 1999; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
-pub const DAYS_GST_TAI_OFFSET: f64 = SECONDS_GST_TAI_OFFSET / SECONDS_PER_DAY;
-/// `SECONDS_BDT_TAI_OFFSET` is the number of seconds from the TAI epoch to the
-/// BDT epoch (UTC midnight January 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-pub const SECONDS_BDT_TAI_OFFSET: f64 = 106.0 * SECONDS_PER_YEAR;
-pub const SECONDS_BDT_TAI_OFFSET_I64: i64 = 106 * SECONDS_PER_YEAR_I64;
-/// `DAYS_BDT_TAI_OFFSET` is the number of days from the TAI epoch to the BDT
-/// epoch (UTC midnight Jan 1st 2006; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-pub const DAYS_BDT_TAI_OFFSET: f64 = SECONDS_BDT_TAI_OFFSET / SECONDS_PER_DAY;
 /// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
 pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
     centuries: 0,

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 
 use core::str::FromStr;
 
-use crate::{Duration, Epoch, Errors, ParsingErrors, SECONDS_PER_DAY, SECONDS_PER_YEAR};
+use crate::{Duration, Epoch, Errors, ParsingErrors, SECONDS_PER_DAY};
 
 /// GPS reference epoch is UTC midnight between 05 January and 06 January 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>.
 pub const GPST_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
@@ -27,11 +27,10 @@ pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
 /// GST (Galileo) reference epoch is 13 seconds before 1999 August 21 UTC at midnight.
 pub const GST_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
     centuries: 0,
-    nanoseconds: 3_144_182_387_000_000_000,
+    nanoseconds: 3_144_268_819_000_000_000,
 });
-pub const SECONDS_GST_TAI_OFFSET: f64 = 3_144_182_387.0;
-pub const SECONDS_GST_TAI_OFFSET_I64: i64 = 3_144_182_387;
-pub const DAYS_GST_TAI_OFFSET: f64 = SECONDS_GST_TAI_OFFSET / SECONDS_PER_YEAR;
+pub const SECONDS_GST_TAI_OFFSET: f64 = 3_144_268_819.0;
+pub const SECONDS_GST_TAI_OFFSET_I64: i64 = 3_144_268_819;
 
 /// BDT(BeiDou): 2005 Dec 31st Midnight
 /// BDT (BeiDou) reference epoch is 2005 December 31st UTC at midnight. **This time scale is synchronized with UTC.**
@@ -41,7 +40,6 @@ pub const BDT_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
 });
 pub const SECONDS_BDT_TAI_OFFSET: f64 = 3_345_062_433.0;
 pub const SECONDS_BDT_TAI_OFFSET_I64: i64 = 3_345_062_433;
-pub const DAYS_BDT_TAI_OFFSET: f64 = SECONDS_BDT_TAI_OFFSET / SECONDS_PER_YEAR;
 
 /// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
 pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -38,11 +38,22 @@ pub enum TimeScale {
 }
 
 impl TimeScale {
+    /// Maximal value when casting to unsigned integer.
+    /// Increment when introducing new timescales.
+    pub const MAX_U8: u8 = 7;
+
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {
-            TimeScale::GPST => 4,
-            TimeScale::TAI | TimeScale::TDB | TimeScale::UTC | TimeScale::GST | TimeScale::BDT => 3,
-            TimeScale::ET | TimeScale::TT => 2,
+            Self::GPST => 4,
+            Self::TAI | Self::TDB | Self::UTC | Self::GST | Self::BDT => 3,
+            Self::ET | Self::TT => 2,
+        }
+    }
+
+    pub(crate) const fn uses_leap(&self) -> bool {
+        match self {
+            Self::UTC => true,
+            _ => false,
         }
     }
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -15,6 +15,7 @@ use core::str::FromStr;
 
 use crate::{
     Errors, ParsingErrors,
+    SECONDS_PER_YEAR, SECONDS_PER_DAY,    
     SECONDS_PER_YEAR_I64, SECONDS_PER_DAY_I64,    
 };
 
@@ -44,6 +45,9 @@ impl TimeScale {
     /// Maximal value when casting to unsigned integer.
     /// Increment when introducing new timescales.
     pub const MAX_U8: u8 = 7;
+    pub const SECONDS_GPS_TAI_OFFSET: f64 = 
+        80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
+    pub const DAYS_GPS_TAI_OFFSET: f64 = Self::SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
     pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 
         80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
     pub(crate) const fn formatted_len(&self) -> usize {
@@ -54,6 +58,7 @@ impl TimeScale {
         }
     }
 
+    /// Returns true if self takes Leap Seconds into account
     pub(crate) const fn uses_leap(&self) -> bool {
         match self {
             Self::UTC => true,

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -13,7 +13,10 @@ use pyo3::prelude::*;
 
 use core::str::FromStr;
 
-use crate::{Errors, ParsingErrors};
+use crate::{
+    Errors, ParsingErrors,
+    SECONDS_PER_YEAR_I64, SECONDS_PER_DAY_I64,    
+};
 
 /// Enum of the different time systems available
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -41,7 +44,8 @@ impl TimeScale {
     /// Maximal value when casting to unsigned integer.
     /// Increment when introducing new timescales.
     pub const MAX_U8: u8 = 7;
-
+    pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 
+        80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {
             Self::GPST => 4,
@@ -54,6 +58,15 @@ impl TimeScale {
         match self {
             Self::UTC => true,
             _ => false,
+        }
+    }
+
+    /// (Positive) offset in seconds, to apply in reference to TAI J1900
+    /// for this timescale
+    pub(crate) const fn tai_j1900_offset_seconds_i64(&self) -> i64 {
+        match self {
+            Self::GPST => Self::SECONDS_GPS_TAI_OFFSET_I64,
+            _ => 0,
         }
     }
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -45,11 +45,32 @@ impl TimeScale {
     /// Maximal value when casting to unsigned integer.
     /// Increment when introducing new timescales.
     pub const MAX_U8: u8 = 7;
+    
+    /// GPS: 1980 Jan 5th Midnight,
+    /// |TAI-UTC| = +19 on that day
     pub const SECONDS_GPS_TAI_OFFSET: f64 = 
         80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
-    pub const DAYS_GPS_TAI_OFFSET: f64 = Self::SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
     pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 
         80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
+    pub const DAYS_GPS_TAI_OFFSET: f64 = Self::SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
+
+    /// GST(Galileo): 1999 August 21st Midnight 
+    /// |TAI-UTC| = +32 on that day, cf. https://en.wikipedia.org/wiki/Leap_second
+    pub const SECONDS_GST_TAI_OFFSET: f64 =
+        /* August 21st midnight: +233 days */
+        99.0 * SECONDS_PER_YEAR + 233.0 * SECONDS_PER_DAY + 32.0;
+    pub const SECONDS_GST_TAI_OFFSET_I64: i64 =
+        99 * SECONDS_PER_YEAR_I64 + 233 * SECONDS_PER_DAY_I64 + 32;
+    pub const DAYS_GST_TAI_OFFSET: f64 = Self::SECONDS_GST_TAI_OFFSET / SECONDS_PER_YEAR;
+    
+    /// BDT(BeiDou): 2005 Dec 31st Midnight
+    /// |TAI-UTC| = +33 on that day, cf. https://en.wikipedia.org/wiki/Leap_second
+    pub const SECONDS_BDT_TAI_OFFSET: f64 =
+        106.0 * SECONDS_PER_YEAR + 33.0;
+    pub const SECONDS_BDT_TAI_OFFSET_I64: i64 =
+        106 * SECONDS_PER_YEAR_I64 + 33;
+    pub const DAYS_BDT_TAI_OFFSET: f64 = Self::SECONDS_BDT_TAI_OFFSET / SECONDS_PER_YEAR;
+
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {
             Self::GPST => 4,
@@ -70,6 +91,8 @@ impl TimeScale {
     /// for this timescale
     pub(crate) const fn tai_j1900_offset_seconds_i64(&self) -> i64 {
         match self {
+            Self::GST  => Self::SECONDS_GST_TAI_OFFSET_I64,
+            Self::BDT  => Self::SECONDS_BDT_TAI_OFFSET_I64,
             Self::GPST => Self::SECONDS_GPS_TAI_OFFSET_I64,
             _ => 0,
         }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -29,21 +29,26 @@ pub enum TimeScale {
     TDB,
     /// Universal Coordinated Time
     UTC,
-    // GPS Time
-    // GPST // TODO
+    /// GPST Time also applies to QZSS, IRNSS and GAL constellations
+    GPST,
+    /// Galileo Time scale 
+    GST,
+    /// BeiDou Time scale
+    BDT,
 }
 
 impl TimeScale {
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {
-            TimeScale::TAI | TimeScale::TDB | TimeScale::UTC => 3,
+            TimeScale::GPST => 4,
+            TimeScale::TAI | TimeScale::TDB | TimeScale::UTC | TimeScale::GST | TimeScale::BDT => 3,
             TimeScale::ET | TimeScale::TT => 2,
         }
     }
 }
 
 /// Allows conversion of a TimeSystem into a u8
-/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4.
+/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4; GPST: 5; GST: 6;
 impl From<TimeScale> for u8 {
     fn from(ts: TimeScale) -> Self {
         match ts {
@@ -52,12 +57,15 @@ impl From<TimeScale> for u8 {
             TimeScale::ET => 2,
             TimeScale::TDB => 3,
             TimeScale::UTC => 4,
+            TimeScale::GPST => 5,
+            TimeScale::GST => 6,
+            TimeScale::BDT => 7,
         }
     }
 }
 
 /// Allows conversion of a u8 into a TimeSystem.
-/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; anything else: TAI
+/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; 5: GPST; 6: GST; anything else: TAI
 impl From<u8> for TimeScale {
     fn from(val: u8) -> Self {
         match val {
@@ -65,6 +73,9 @@ impl From<u8> for TimeScale {
             2 => Self::ET,
             3 => Self::TDB,
             4 => Self::UTC,
+            5 => Self::GPST,
+            6 => Self::GST,
+            7 => Self::BDT,
             _ => Self::TAI,
         }
     }
@@ -85,6 +96,12 @@ impl FromStr for TimeScale {
             Ok(Self::TDB)
         } else if val == "ET" {
             Ok(Self::ET)
+        } else if val == "GPST" {
+            Ok(Self::GPST)
+        } else if val == "GST" {
+            Ok(Self::GST)
+        } else if val == "BDT" {
+            Ok(Self::BDT)
         } else {
             Err(Errors::ParseError(ParsingErrors::TimeSystem))
         }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -77,9 +77,12 @@ impl TimeScale {
             Self::ET | Self::TT => 2,
         }
     }
+}
 
+#[cfg_attr(feature = "python", pymethods)]
+impl TimeScale {
     /// Returns true if self takes leap seconds into account
-    pub(crate) const fn uses_leap_seconds(&self) -> bool {
+    pub const fn uses_leap_seconds(&self) -> bool {
         matches!(self, Self::UTC)
     }
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -48,7 +48,7 @@ impl TimeScale {
 }
 
 /// Allows conversion of a TimeSystem into a u8
-/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4; GPST: 5; GST: 6;
+/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4; GPST: 5; GST: 6; BDT: 7;
 impl From<TimeScale> for u8 {
     fn from(ts: TimeScale) -> Self {
         match ts {
@@ -65,7 +65,7 @@ impl From<TimeScale> for u8 {
 }
 
 /// Allows conversion of a u8 into a TimeSystem.
-/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; 5: GPST; 6: GST; anything else: TAI
+/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; 5: GPST; 6: GST; 7: BDT; anything else: TAI
 impl From<u8> for TimeScale {
     fn from(val: u8) -> Self {
         match val {

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -13,11 +13,41 @@ use pyo3::prelude::*;
 
 use core::str::FromStr;
 
-use crate::{
-    Errors, ParsingErrors,
-    SECONDS_PER_YEAR, SECONDS_PER_DAY,    
-    SECONDS_PER_YEAR_I64, SECONDS_PER_DAY_I64,    
-};
+use crate::{Duration, Epoch, Errors, ParsingErrors, SECONDS_PER_DAY, SECONDS_PER_YEAR};
+
+/// GPS reference epoch is UTC midnight between 05 January and 06 January 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>.
+pub const GPST_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
+    centuries: 0,
+    nanoseconds: 2_524_953_619_000_000_000,
+});
+pub const SECONDS_GPS_TAI_OFFSET: f64 = 2_524_953_619.0;
+pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 2_524_953_619;
+pub const DAYS_GPS_TAI_OFFSET: f64 = SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
+
+/// GST (Galileo) reference epoch is 13 seconds before 1999 August 21 UTC at midnight.
+pub const GST_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
+    centuries: 0,
+    nanoseconds: 3_144_182_387_000_000_000,
+});
+pub const SECONDS_GST_TAI_OFFSET: f64 = 3_144_182_387.0;
+pub const SECONDS_GST_TAI_OFFSET_I64: i64 = 3_144_182_387;
+pub const DAYS_GST_TAI_OFFSET: f64 = SECONDS_GST_TAI_OFFSET / SECONDS_PER_YEAR;
+
+/// BDT(BeiDou): 2005 Dec 31st Midnight
+/// BDT (BeiDou) reference epoch is 2005 December 31st UTC at midnight. **This time scale is synchronized with UTC.**
+pub const BDT_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
+    centuries: 1,
+    nanoseconds: 189_302_433_000_000_000,
+});
+pub const SECONDS_BDT_TAI_OFFSET: f64 = 3_345_062_433.0;
+pub const SECONDS_BDT_TAI_OFFSET_I64: i64 = 3_345_062_433;
+pub const DAYS_BDT_TAI_OFFSET: f64 = SECONDS_BDT_TAI_OFFSET / SECONDS_PER_YEAR;
+
+/// The UNIX reference epoch of 1970-01-01 in TAI duration, accounting only for IERS leap seconds.
+pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
+    centuries: 0,
+    nanoseconds: 2_208_988_800_000_000_000,
+});
 
 /// Enum of the different time systems available
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -35,42 +65,13 @@ pub enum TimeScale {
     UTC,
     /// GPST Time also applies to QZSS, IRNSS and GAL constellations
     GPST,
-    /// Galileo Time scale 
+    /// Galileo Time scale
     GST,
     /// BeiDou Time scale
     BDT,
 }
 
 impl TimeScale {
-    /// Maximal value when casting to unsigned integer.
-    /// Increment when introducing new timescales.
-    pub const MAX_U8: u8 = 7;
-    
-    /// GPS: 1980 Jan 5th Midnight,
-    /// |TAI-UTC| = +19 on that day
-    pub const SECONDS_GPS_TAI_OFFSET: f64 = 
-        80.0 * SECONDS_PER_YEAR + 4.0 * SECONDS_PER_DAY + 19.0;
-    pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 
-        80 * SECONDS_PER_YEAR_I64 + 4 * SECONDS_PER_DAY_I64 + 19;
-    pub const DAYS_GPS_TAI_OFFSET: f64 = Self::SECONDS_GPS_TAI_OFFSET / SECONDS_PER_DAY;
-
-    /// GST(Galileo): 1999 August 21st Midnight 
-    /// |TAI-UTC| = +32 on that day, cf. https://en.wikipedia.org/wiki/Leap_second
-    pub const SECONDS_GST_TAI_OFFSET: f64 =
-        /* August 21st midnight: +233 days */
-        99.0 * SECONDS_PER_YEAR + 233.0 * SECONDS_PER_DAY + 32.0;
-    pub const SECONDS_GST_TAI_OFFSET_I64: i64 =
-        99 * SECONDS_PER_YEAR_I64 + 233 * SECONDS_PER_DAY_I64 + 32;
-    pub const DAYS_GST_TAI_OFFSET: f64 = Self::SECONDS_GST_TAI_OFFSET / SECONDS_PER_YEAR;
-    
-    /// BDT(BeiDou): 2005 Dec 31st Midnight
-    /// |TAI-UTC| = +33 on that day, cf. https://en.wikipedia.org/wiki/Leap_second
-    pub const SECONDS_BDT_TAI_OFFSET: f64 =
-        106.0 * SECONDS_PER_YEAR + 33.0;
-    pub const SECONDS_BDT_TAI_OFFSET_I64: i64 =
-        106 * SECONDS_PER_YEAR_I64 + 33;
-    pub const DAYS_BDT_TAI_OFFSET: f64 = Self::SECONDS_BDT_TAI_OFFSET / SECONDS_PER_YEAR;
-
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {
             Self::GPST => 4,
@@ -79,23 +80,9 @@ impl TimeScale {
         }
     }
 
-    /// Returns true if self takes Leap Seconds into account
-    pub(crate) const fn uses_leap(&self) -> bool {
-        match self {
-            Self::UTC => true,
-            _ => false,
-        }
-    }
-
-    /// (Positive) offset in seconds, to apply in reference to TAI J1900
-    /// for this timescale
-    pub(crate) const fn tai_j1900_offset_seconds_i64(&self) -> i64 {
-        match self {
-            Self::GST  => Self::SECONDS_GST_TAI_OFFSET_I64,
-            Self::BDT  => Self::SECONDS_BDT_TAI_OFFSET_I64,
-            Self::GPST => Self::SECONDS_GPS_TAI_OFFSET_I64,
-            _ => 0,
-        }
+    /// Returns true if self takes leap seconds into account
+    pub(crate) const fn uses_leap_seconds(&self) -> bool {
+        matches!(self, Self::UTC)
     }
 }
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2,8 +2,8 @@
 extern crate core;
 
 use hifitime::{
-    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, DAYS_GPS_TAI_OFFSET,
-    J1900_OFFSET, J2000_OFFSET, MJD_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_PER_DAY,
+    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, 
+    J1900_OFFSET, J2000_OFFSET, MJD_OFFSET, SECONDS_PER_DAY,
 };
 
 #[cfg(feature = "std")]
@@ -218,15 +218,14 @@ fn gnss_epochs() {
     // Test 1sec into GNSS timescales 
     let gnss = Epoch::from_gpst_seconds(1.0);
     assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
-    let gnss = Epoch::from_bdt_seconds(1.0);
-    assert_eq!(gnss, ref_bds + 1.0 * Unit::Second);
+    //let gnss = Epoch::from_bdt_seconds(1.0);
+    //assert_eq!(gnss, ref_bds + 1.0 * Unit::Second);
     //let gnss = Epoch::from_gst_seconds(1.0);
     //assert_eq!(gnss, ref_gal + 1.0 * Unit::Second);
     
     // Test 1+1/2 day into GNSS timescales
     let gnss = Epoch::from_gpst_days(1.5);
     assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
-
 }
 
 #[test]
@@ -318,6 +317,7 @@ fn datetime_invalid_dates() {
     assert!(!is_gregorian_valid(2015, 6, 30, 23, 59, 61, 0));
 }
 
+/*
 #[test]
 fn gpst() {
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
@@ -381,7 +381,7 @@ fn gpst() {
     let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
     assert!((epoch.to_gpst_seconds() + 5.0 * SECONDS_PER_DAY).abs() < EPSILON);
     assert!((epoch.to_gpst_days() + 5.0).abs() < EPSILON);
-}
+}*/
 
 #[test]
 fn unix() {

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -378,6 +378,124 @@ fn gpst() {
 }
 
 #[test]
+fn galileo_time_scale() {
+    let tai_offset = TimeScale::SECONDS_GST_TAI_OFFSET;
+    let days_tai_offset = TimeScale::DAYS_GST_TAI_OFFSET;
+    let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
+    let gst_nanos = now.to_gst_nanoseconds().unwrap();
+    assert_eq!(
+        Epoch::from_gst_nanoseconds(gst_nanos),
+        now,
+        "To/from (recip.) GPST nanoseconds failed"
+    );
+    assert!(
+        (now.to_tai_seconds() - tai_offset - now.to_gst_seconds()).abs() < EPSILON
+    );
+    assert!(
+        now.to_gst_seconds() + tai_offset > now.to_utc_seconds(),
+        "GST Time is not ahead of UTC"
+    );
+
+    let epoch = Epoch::from_tai_seconds(tai_offset);
+    #[cfg(feature = "std")]
+    {
+        assert_eq!(
+            epoch.to_gregorian_str(TimeScale::UTC),
+            "1999-08-22T00:00:00 UTC"
+        );
+        assert_eq!(
+            epoch.to_gregorian_str(TimeScale::TAI),
+            "1999-08-22T00:00:32 TAI"
+        );
+        assert_eq!(format!("{:o}", epoch), "0");
+    }
+    assert_eq!(
+        epoch.to_tai_seconds(),
+        Epoch::from_gregorian_utc_at_midnight(1999, 08, 22).to_tai_seconds()
+    );
+    assert!(
+        epoch.to_gst_seconds().abs() < EPSILON,
+        "The number of seconds from the GST epoch was not 0: {}",
+        epoch.to_gst_seconds()
+    );
+    assert!(
+        epoch.to_gst_days().abs() < EPSILON,
+        "The number of days from the GST epoch was not 0: {}",
+        epoch.to_gst_days()
+    );
+
+    //let epoch = Epoch::from_gregorian_utc_at_midnight(1972, 1, 1);
+    //assert!(
+    //    (epoch.to_tai_seconds() - tai_offset - epoch.to_gpst_seconds()).abs() < EPSILON
+    //);
+    //assert!((epoch.to_tai_days() - days_tai_offset - epoch.to_gpst_days()).abs() < 1e-11);
+
+    // 1 Jan 1980 is 5 days before the GPS epoch.
+    //let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
+    //assert!((epoch.to_gst_seconds() + 5.0 * SECONDS_PER_DAY).abs() < EPSILON);
+    //assert!((epoch.to_gst_days() + 5.0).abs() < EPSILON);
+}
+
+#[test]
+fn beidou_time_scale() {
+    let tai_offset = TimeScale::SECONDS_BDT_TAI_OFFSET;
+    let days_tai_offset = TimeScale::DAYS_BDT_TAI_OFFSET;
+    let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
+    let nanos = now.to_bdt_nanoseconds().unwrap();
+    assert_eq!(
+        Epoch::from_bdt_nanoseconds(nanos),
+        now,
+        "To/from (recip.) BDT nanoseconds failed"
+    );
+    assert!(
+        (now.to_tai_seconds() - tai_offset - now.to_bdt_seconds()).abs() < EPSILON
+    );
+    assert!(
+        now.to_bdt_seconds() + tai_offset > now.to_utc_seconds(),
+        "BDT Time is not ahead of UTC"
+    );
+
+    let epoch = Epoch::from_tai_seconds(tai_offset);
+    #[cfg(feature = "std")]
+    {
+        assert_eq!(
+            epoch.to_gregorian_str(TimeScale::UTC),
+            "2006-01-01T00:00:00 UTC"
+        );
+        assert_eq!(
+            epoch.to_gregorian_str(TimeScale::TAI),
+            "2006-01-01T00:00:33 TAI"
+        );
+        assert_eq!(format!("{:o}", epoch), "0");
+    }
+    assert_eq!(
+        epoch.to_tai_seconds(),
+        Epoch::from_gregorian_utc_at_midnight(2006, 01, 01).to_tai_seconds()
+    );
+    assert!(
+        epoch.to_bdt_seconds().abs() < EPSILON,
+        "The number of seconds from the BDT epoch was not 0: {}",
+        epoch.to_bdt_seconds()
+    );
+    assert!(
+        epoch.to_bdt_days().abs() < EPSILON,
+        "The number of days from the BDT epoch was not 0: {}",
+        epoch.to_bdt_days()
+    );
+
+    //let epoch = Epoch::from_gregorian_utc_at_midnight(1972, 1, 1);
+    //assert!(
+    //    (epoch.to_tai_seconds() - tai_offset - epoch.to_gpst_seconds()).abs() < EPSILON
+    //);
+    //assert!((epoch.to_tai_days() - days_tai_offset - epoch.to_gpst_days()).abs() < 1e-11);
+
+    // 1 Jan 1980 is 5 days before the GPS epoch.
+    //let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
+    //assert!((epoch.to_gst_seconds() + 5.0 * SECONDS_PER_DAY).abs() < EPSILON);
+    //assert!((epoch.to_gst_days() + 5.0).abs() < EPSILON);
+}
+
+#[test]
 fn unix() {
     // Continuous check that the system time as reported by this machine is within millisecond accuracy of what we compute
     #[cfg(feature = "std")]

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -207,25 +207,17 @@ fn utc_tai() {
         Epoch::from_gregorian_utc_at_midnight(1972, 1, 1),
         Epoch::from_utc_days(26297.0)
     );
-}
-
-#[test]
-fn gnss_epochs() {
-    let ref_gps = Epoch::from_gregorian_utc_at_midnight(1980, 01, 06);
-    let ref_bds = Epoch::from_gregorian_utc_at_midnight(2006, 01, 01);
-    let ref_gal = Epoch::from_gregorian_utc_at_midnight(1999, 07, 22) - 13.0 * Unit::Second;
     
-    // Test 1sec into GNSS timescales 
-    let gnss = Epoch::from_gpst_seconds(1.0);
-    assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
-    //let gnss = Epoch::from_bdt_seconds(1.0);
-    //assert_eq!(gnss, ref_bds + 1.0 * Unit::Second);
-    //let gnss = Epoch::from_gst_seconds(1.0);
-    //assert_eq!(gnss, ref_gal + 1.0 * Unit::Second);
-    
-    // Test 1+1/2 day into GNSS timescales
-    let gnss = Epoch::from_gpst_days(1.5);
-    assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
+    let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
+    assert!(
+        now.to_tai_seconds() > now.to_utc_seconds(),
+        "TAI is not ahead of UTC"
+    );
+    assert!((now.to_tai_seconds() - now.to_utc_seconds() - 37.0).abs() < EPSILON);
+    assert!(
+        now.to_tai_seconds() > now.to_gpst_seconds(),
+        "TAI is not ahead of GPS Time"
+    );
 }
 
 #[test]
@@ -317,33 +309,35 @@ fn datetime_invalid_dates() {
     assert!(!is_gregorian_valid(2015, 6, 30, 23, 59, 61, 0));
 }
 
-/*
 #[test]
 fn gpst() {
+    let tai_offset = TimeScale::SECONDS_GPS_TAI_OFFSET;
+    let days_tai_offset = TimeScale::DAYS_GPS_TAI_OFFSET;
+    let ref_gps = Epoch::from_gregorian_utc_at_midnight(1980, 01, 06);
+    
+    // Test 1sec into GPS timescale
+    let gnss = Epoch::from_gpst_seconds(1.0);
+    assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
+    
+    // Test 1+1/2 day into GPS timescale
+    let gnss = Epoch::from_gpst_days(1.5);
+    assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
+
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
-    assert!(
-        now.to_tai_seconds() > now.to_utc_seconds(),
-        "TAI is not ahead of UTC"
-    );
-    assert!((now.to_tai_seconds() - now.to_utc_seconds() - 37.0).abs() < EPSILON);
-    assert!(
-        now.to_tai_seconds() > now.to_gpst_seconds(),
-        "TAI is not ahead of GPS Time"
-    );
     assert_eq!(
         Epoch::from_gpst_nanoseconds(now.to_gpst_nanoseconds().unwrap()),
         now,
-        "To/from GPST nanoseconds failed"
+        "To/from (recip.) GPST nanoseconds failed"
     );
     assert!(
-        (now.to_tai_seconds() - SECONDS_GPS_TAI_OFFSET - now.to_gpst_seconds()).abs() < EPSILON
+        (now.to_tai_seconds() - tai_offset - now.to_gpst_seconds()).abs() < EPSILON
     );
     assert!(
-        now.to_gpst_seconds() + SECONDS_GPS_TAI_OFFSET > now.to_utc_seconds(),
+        now.to_gpst_seconds() + tai_offset > now.to_utc_seconds(),
         "GPS Time is not ahead of UTC"
     );
 
-    let gps_epoch = Epoch::from_tai_seconds(SECONDS_GPS_TAI_OFFSET);
+    let gps_epoch = Epoch::from_tai_seconds(tai_offset);
     #[cfg(feature = "std")]
     {
         assert_eq!(
@@ -373,15 +367,15 @@ fn gpst() {
 
     let epoch = Epoch::from_gregorian_utc_at_midnight(1972, 1, 1);
     assert!(
-        (epoch.to_tai_seconds() - SECONDS_GPS_TAI_OFFSET - epoch.to_gpst_seconds()).abs() < EPSILON
+        (epoch.to_tai_seconds() - tai_offset - epoch.to_gpst_seconds()).abs() < EPSILON
     );
-    assert!((epoch.to_tai_days() - DAYS_GPS_TAI_OFFSET - epoch.to_gpst_days()).abs() < 1e-11);
+    assert!((epoch.to_tai_days() - days_tai_offset - epoch.to_gpst_days()).abs() < 1e-11);
 
     // 1 Jan 1980 is 5 days before the GPS epoch.
     let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
     assert!((epoch.to_gpst_seconds() + 5.0 * SECONDS_PER_DAY).abs() < EPSILON);
     assert!((epoch.to_gpst_days() + 5.0).abs() < EPSILON);
-}*/
+}
 
 #[test]
 fn unix() {

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -884,7 +884,7 @@ fn test_format() {
     assert_eq!(format!("{epoch:o}"), "1346541887000000000"); // GPS nanoseconds
 
     // Ensure that the appropriate time system is used in the debug print.
-    for ts_u8 in 0..5 {
+    for ts_u8 in 0..=7 {
         let ts: TimeScale = ts_u8.into();
 
         let recent = Epoch::from_gregorian(2020, 9, 6, 23, 24, 29, 2, ts);
@@ -925,9 +925,9 @@ fn test_format() {
                     TimeScale::TDB => format!("{epoch:e}"),
                     TimeScale::TT => format!("{epoch:X}"),
                     TimeScale::UTC => format!("{epoch}"),
-                    TimeScale::GPST => format!("{epoch}"),
-                    TimeScale::GST => format!("{epoch}"),
-                    TimeScale::BDT => format!("{epoch}"),
+                    TimeScale::GPST => format!("{epoch:x}").replace("TAI", "GPST"),
+                    TimeScale::GST => format!("{epoch:x}").replace("TAI", "GST"),
+                    TimeScale::BDT => format!("{epoch:x}").replace("TAI", "BDT"),
                 }
             );
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -210,6 +210,26 @@ fn utc_tai() {
 }
 
 #[test]
+fn gnss_epochs() {
+    let ref_gps = Epoch::from_gregorian_utc_at_midnight(1980, 01, 06);
+    let ref_bds = Epoch::from_gregorian_utc_at_midnight(2006, 01, 01);
+    let ref_gal = Epoch::from_gregorian_utc_at_midnight(1999, 07, 22) - 13.0 * Unit::Second;
+    
+    // Test 1sec into GNSS timescales 
+    let gnss = Epoch::from_gpst_seconds(1.0);
+    assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
+    let gnss = Epoch::from_bdt_seconds(1.0);
+    assert_eq!(gnss, ref_bds + 1.0 * Unit::Second);
+    //let gnss = Epoch::from_gst_seconds(1.0);
+    //assert_eq!(gnss, ref_gal + 1.0 * Unit::Second);
+    
+    // Test 1+1/2 day into GNSS timescales
+    let gnss = Epoch::from_gpst_days(1.5);
+    assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
+
+}
+
+#[test]
 fn julian_epoch() {
     // X-Val: https://heasarc.gsfc.nasa.gov/cgi-bin/Tools/xTime/xTime.pl?time_in_i=1900-01-01+00%3A00%3A00&time_in_c=&time_in_d=&time_in_j=&time_in_m=&time_in_sf=&time_in_wf=&time_in_sl=&time_in_snu=&time_in_s=&time_in_h=&time_in_n=&time_in_f=&time_in_sz=&time_in_ss=&time_in_sn=&timesys_in=u&timesys_out=u&apply_clock_offset=yes
     // X-Val: https://heasarc.gsfc.nasa.gov/cgi-bin/Tools/xTime/xTime.pl?time_in_i=1900-01-01+00%3A00%3A00&time_in_c=&time_in_d=&time_in_j=&time_in_m=&time_in_sf=&time_in_wf=&time_in_sl=&time_in_snu=&time_in_s=&time_in_h=&time_in_n=&time_in_f=&time_in_sz=&time_in_ss=&time_in_sn=&timesys_in=u&timesys_out=u&apply_clock_offset=yes

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2,9 +2,9 @@
 extern crate core;
 
 use hifitime::{
-    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, DAYS_GPS_TAI_OFFSET,
-    GPST_REF_EPOCH, GST_REF_EPOCH, J1900_OFFSET, J2000_OFFSET, MJD_OFFSET, SECONDS_BDT_TAI_OFFSET,
-    SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET, SECONDS_PER_DAY,
+    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, BDT_REF_EPOCH,
+    DAYS_GPS_TAI_OFFSET, GPST_REF_EPOCH, GST_REF_EPOCH, J1900_OFFSET, J2000_OFFSET, MJD_OFFSET,
+    SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET, SECONDS_PER_DAY,
 };
 
 #[cfg(feature = "std")]
@@ -340,6 +340,10 @@ fn gpst() {
     assert_eq!(format!("{}", GPST_REF_EPOCH), "1980-01-06T00:00:00 UTC");
     assert_eq!(format!("{:x}", GPST_REF_EPOCH), "1980-01-06T00:00:19 TAI");
     assert_eq!(format!("{:o}", gps_epoch), "0");
+    assert_eq!(
+        Epoch::from_gpst_days(0.0).to_duration_since_j1900(),
+        gps_epoch.duration_since_j1900_tai
+    );
 
     assert_eq!(
         gps_epoch.to_tai_seconds(),
@@ -386,27 +390,31 @@ fn galileo_time_scale() {
     let ref_gst = Epoch::from_gst_nanoseconds(0);
     assert_eq!(format!("{}", ref_gst), "1999-08-21T23:59:47 UTC");
 
-    let epoch = Epoch::from_tai_seconds(SECONDS_GST_TAI_OFFSET);
-    assert_eq!(epoch, Epoch::from_gst_days(0.0));
-    assert_eq!(epoch, Epoch::from_gst_seconds(0.0));
-    assert_eq!(epoch, Epoch::from_gst_nanoseconds(0));
-    assert_eq!(epoch, GST_REF_EPOCH);
+    let gst_epoch = Epoch::from_tai_seconds(SECONDS_GST_TAI_OFFSET);
+    assert_eq!(gst_epoch, Epoch::from_gst_days(0.0));
+    assert_eq!(gst_epoch, Epoch::from_gst_seconds(0.0));
+    assert_eq!(gst_epoch, Epoch::from_gst_nanoseconds(0));
+    assert_eq!(gst_epoch, GST_REF_EPOCH);
     assert_eq!(format!("{}", GST_REF_EPOCH), "1999-08-21T23:59:47 UTC");
     assert_eq!(format!("{:x}", GST_REF_EPOCH), "1999-08-22T00:00:19 TAI");
+    assert_eq!(
+        Epoch::from_gst_days(0.0).to_duration_since_j1900(),
+        gst_epoch.duration_since_j1900_tai
+    );
 
     assert_eq!(
-        epoch.to_tai_seconds(),
+        gst_epoch.to_tai_seconds(),
         Epoch::from_gregorian_utc_at_midnight(1999, 08, 22).to_tai_seconds() - 13.0
     );
     assert!(
-        epoch.to_gst_seconds().abs() < EPSILON,
+        gst_epoch.to_gst_seconds().abs() < EPSILON,
         "The number of seconds from the GST epoch was not 0: {}",
-        epoch.to_gst_seconds()
+        gst_epoch.to_gst_seconds()
     );
     assert!(
-        epoch.to_gst_days().abs() < EPSILON,
+        gst_epoch.to_gst_days().abs() < EPSILON,
         "The number of days from the GST epoch was not 0: {}",
-        epoch.to_gst_days()
+        gst_epoch.to_gst_days()
     );
 }
 
@@ -425,27 +433,33 @@ fn beidou_time_scale() {
         "BDT Time is not ahead of UTC"
     );
 
-    let epoch = Epoch::from_tai_seconds(SECONDS_BDT_TAI_OFFSET);
-    assert_eq!(epoch, Epoch::from_bdt_days(0.0));
-    assert_eq!(epoch, Epoch::from_bdt_seconds(0.0));
-    assert_eq!(epoch, Epoch::from_bdt_nanoseconds(0));
+    let bdt_epoch = Epoch::from_tai_seconds(SECONDS_BDT_TAI_OFFSET);
+    assert_eq!(bdt_epoch, Epoch::from_bdt_days(0.0));
+    assert_eq!(bdt_epoch, Epoch::from_bdt_seconds(0.0));
+    assert_eq!(bdt_epoch, Epoch::from_bdt_nanoseconds(0));
+    assert_eq!(bdt_epoch, BDT_REF_EPOCH);
 
-    assert_eq!(format!("{epoch}"), "2006-01-01T00:00:00 UTC");
-    assert_eq!(format!("{epoch:x}"), "2006-01-01T00:00:33 TAI");
+    assert_eq!(format!("{bdt_epoch}"), "2006-01-01T00:00:00 UTC");
+    assert_eq!(format!("{bdt_epoch:x}"), "2006-01-01T00:00:33 TAI");
 
     assert_eq!(
-        epoch.to_tai_seconds(),
+        Epoch::from_bdt_days(0.0).to_duration_since_j1900(),
+        bdt_epoch.duration_since_j1900_tai
+    );
+
+    assert_eq!(
+        bdt_epoch.to_tai_seconds(),
         Epoch::from_gregorian_utc_at_midnight(2006, 01, 01).to_tai_seconds()
     );
     assert!(
-        epoch.to_bdt_seconds().abs() < EPSILON,
+        bdt_epoch.to_bdt_seconds().abs() < EPSILON,
         "The number of seconds from the BDT epoch was not 0: {}",
-        epoch.to_bdt_seconds()
+        bdt_epoch.to_bdt_seconds()
     );
     assert!(
-        epoch.to_bdt_days().abs() < EPSILON,
+        bdt_epoch.to_bdt_days().abs() < EPSILON,
         "The number of days from the BDT epoch was not 0: {}",
-        epoch.to_bdt_days()
+        bdt_epoch.to_bdt_days()
     );
 }
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -825,6 +825,9 @@ fn test_format() {
                     TimeScale::TDB => format!("{epoch:e}"),
                     TimeScale::TT => format!("{epoch:X}"),
                     TimeScale::UTC => format!("{epoch}"),
+                    TimeScale::GPST => format!("{epoch}"),
+                    TimeScale::GST => format!("{epoch}"),
+                    TimeScale::BDT => format!("{epoch}"),
                 }
             );
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2,8 +2,10 @@
 extern crate core;
 
 use hifitime::{
-    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, 
-    J1900_OFFSET, J2000_OFFSET, MJD_OFFSET, SECONDS_PER_DAY,
+    is_gregorian_valid, Duration, Epoch, TimeScale, TimeUnits, Unit, DAYS_BDT_TAI_OFFSET,
+    DAYS_GPS_TAI_OFFSET, DAYS_GST_TAI_OFFSET, GPST_REF_EPOCH, J1900_OFFSET, J2000_OFFSET,
+    MJD_OFFSET, SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET,
+    SECONDS_PER_DAY,
 };
 
 #[cfg(feature = "std")]
@@ -207,7 +209,7 @@ fn utc_tai() {
         Epoch::from_gregorian_utc_at_midnight(1972, 1, 1),
         Epoch::from_utc_days(26297.0)
     );
-    
+
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
     assert!(
         now.to_tai_seconds() > now.to_utc_seconds(),
@@ -311,14 +313,12 @@ fn datetime_invalid_dates() {
 
 #[test]
 fn gpst() {
-    let tai_offset = TimeScale::SECONDS_GPS_TAI_OFFSET;
-    let days_tai_offset = TimeScale::DAYS_GPS_TAI_OFFSET;
     let ref_gps = Epoch::from_gregorian_utc_at_midnight(1980, 01, 06);
-    
+
     // Test 1sec into GPS timescale
     let gnss = Epoch::from_gpst_seconds(1.0);
     assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
-    
+
     // Test 1+1/2 day into GPS timescale
     let gnss = Epoch::from_gpst_days(1.5);
     assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
@@ -330,18 +330,18 @@ fn gpst() {
         "To/from (recip.) GPST nanoseconds failed"
     );
     assert!(
-        (now.to_tai_seconds() - tai_offset - now.to_gpst_seconds()).abs() < EPSILON
+        (now.to_tai_seconds() - SECONDS_GPS_TAI_OFFSET - now.to_gpst_seconds()).abs() < EPSILON
     );
     assert!(
-        now.to_gpst_seconds() + tai_offset > now.to_utc_seconds(),
+        now.to_gpst_seconds() + SECONDS_GPS_TAI_OFFSET > now.to_utc_seconds(),
         "GPS Time is not ahead of UTC"
     );
 
-    let gps_epoch = Epoch::from_tai_seconds(tai_offset);
+    let gps_epoch = Epoch::from_tai_seconds(SECONDS_GPS_TAI_OFFSET);
     #[cfg(feature = "std")]
     {
         assert_eq!(
-            gps_epoch.to_gregorian_str(TimeScale::UTC),
+            GPST_REF_EPOCH.to_gregorian_str(TimeScale::UTC),
             "1980-01-06T00:00:00 UTC"
         );
         assert_eq!(
@@ -367,9 +367,9 @@ fn gpst() {
 
     let epoch = Epoch::from_gregorian_utc_at_midnight(1972, 1, 1);
     assert!(
-        (epoch.to_tai_seconds() - tai_offset - epoch.to_gpst_seconds()).abs() < EPSILON
+        (epoch.to_tai_seconds() - SECONDS_GPS_TAI_OFFSET - epoch.to_gpst_seconds()).abs() < EPSILON
     );
-    assert!((epoch.to_tai_days() - days_tai_offset - epoch.to_gpst_days()).abs() < 1e-11);
+    assert!((epoch.to_tai_days() - DAYS_GPS_TAI_OFFSET - epoch.to_gpst_days()).abs() < 1e-11);
 
     // 1 Jan 1980 is 5 days before the GPS epoch.
     let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
@@ -379,8 +379,8 @@ fn gpst() {
 
 #[test]
 fn galileo_time_scale() {
-    let tai_offset = TimeScale::SECONDS_GST_TAI_OFFSET;
-    let days_tai_offset = TimeScale::DAYS_GST_TAI_OFFSET;
+    let tai_offset = SECONDS_GST_TAI_OFFSET;
+    let days_tai_offset = DAYS_GST_TAI_OFFSET;
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
     let gst_nanos = now.to_gst_nanoseconds().unwrap();
     assert_eq!(
@@ -388,9 +388,7 @@ fn galileo_time_scale() {
         now,
         "To/from (recip.) GPST nanoseconds failed"
     );
-    assert!(
-        (now.to_tai_seconds() - tai_offset - now.to_gst_seconds()).abs() < EPSILON
-    );
+    assert!((now.to_tai_seconds() - tai_offset - now.to_gst_seconds()).abs() < EPSILON);
     assert!(
         now.to_gst_seconds() + tai_offset > now.to_utc_seconds(),
         "GST Time is not ahead of UTC"
@@ -438,8 +436,8 @@ fn galileo_time_scale() {
 
 #[test]
 fn beidou_time_scale() {
-    let tai_offset = TimeScale::SECONDS_BDT_TAI_OFFSET;
-    let days_tai_offset = TimeScale::DAYS_BDT_TAI_OFFSET;
+    let tai_offset = SECONDS_BDT_TAI_OFFSET;
+    let days_tai_offset = DAYS_BDT_TAI_OFFSET;
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
     let nanos = now.to_bdt_nanoseconds().unwrap();
     assert_eq!(
@@ -447,9 +445,7 @@ fn beidou_time_scale() {
         now,
         "To/from (recip.) BDT nanoseconds failed"
     );
-    assert!(
-        (now.to_tai_seconds() - tai_offset - now.to_bdt_seconds()).abs() < EPSILON
-    );
+    assert!((now.to_tai_seconds() - tai_offset - now.to_bdt_seconds()).abs() < EPSILON);
     assert!(
         now.to_bdt_seconds() + tai_offset > now.to_utc_seconds(),
         "BDT Time is not ahead of UTC"


### PR DESCRIPTION
GST: Galileo System time is defined as starting 13 seconds
prior midnight on August 22nd 1999
GPST: GPS System time is defined as starting on Jan 6 1980 midnight
BDT: BeiDou system time scale, defined as starting on Jan 1st 2006 midnight.

All of them do not take leap second into account.

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>