### PR TITLE
timecale.rs: introduce format/display

### DIFF
--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -81,10 +81,7 @@ impl TimeScale {
 
     /// Returns true if Self is based off a GNSS constellation
     pub const fn is_gnss(&self) -> bool {
-        match &self {
-            Self::GPST | Self::GST | Self::BDT => true,
-            _ => false,
-        }
+        matches!(self, Self::GPST | Self::GST | Self::BDT)
     }
 }
 
@@ -112,7 +109,7 @@ impl fmt::LowerHex for TimeScale {
             Self::GPST => write!(f, "GPS"),
             Self::GST => write!(f, "GAL"),
             Self::BDT => write!(f, "BDS"),
-            s => write!(f, "{}", s),
+            _ => write!(f, "{self}"),
         }
     }
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -11,6 +11,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+use core::fmt;
 use core::str::FromStr;
 
 use crate::{Duration, Epoch, Errors, ParsingErrors, SECONDS_PER_DAY};
@@ -75,6 +76,43 @@ impl TimeScale {
             Self::GPST => 4,
             Self::TAI | Self::TDB | Self::UTC | Self::GST | Self::BDT => 3,
             Self::ET | Self::TT => 2,
+        }
+    }
+
+    /// Returns true if Self is based off a GNSS constellation
+    pub const fn is_gnss(&self) -> bool {
+        match &self {
+            Self::GPST | Self::GST | Self::BDT => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for TimeScale {
+    /// Prints given TimeScale
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::TAI => write!(f, "TAI"),
+            Self::TT => write!(f, "TT"),
+            Self::ET => write!(f, "ET"),
+            Self::TDB => write!(f, "TDB"),
+            Self::UTC => write!(f, "UTC"),
+            Self::GPST => write!(f, "GPST"),
+            Self::GST => write!(f, "GST"),
+            Self::BDT => write!(f, "BDT"),
+        }
+    }
+}
+
+impl fmt::LowerHex for TimeScale {
+    /// Prints given TimeScale in RINEX format
+    /// ie., standard GNSS constellation name is prefered when possible
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::GPST => write!(f, "GPS"),
+            Self::GST => write!(f, "GAL"),
+            Self::BDT => write!(f, "BDS"),
+            s => write!(f, "{}", s),
         }
     }
 }

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -1,0 +1,45 @@
+extern crate hifitime;
+use hifitime::TimeScale;
+use std::str::FromStr;
+
+#[test]
+fn test_from_str() {
+    let values = vec![
+        ("TAI", TimeScale::TAI),
+        ("UTC", TimeScale::UTC),
+        ("TT", TimeScale::TT),
+        ("TDB", TimeScale::TDB),
+        ("GPST", TimeScale::GPST),
+        ("GST", TimeScale::GST),
+        ("BDT", TimeScale::BDT),
+    ];
+    for value in values {
+        let (descriptor, expected) = value;
+        let ts = TimeScale::from_str(descriptor);
+        assert_eq!(ts.is_ok(), true);
+        let ts = ts.unwrap();
+        assert_eq!(ts, expected);
+        // test to_str()/format()
+        assert_eq!(format!("{}", ts), descriptor);
+        // test format(0x)
+        let expected: &str = match ts {
+            TimeScale::GPST => "GPS",
+            TimeScale::GST => "GAL",
+            TimeScale::BDT => "BDS",
+            _ => descriptor, // untouched
+        };
+        assert_eq!(format!("{:x}", ts), expected);
+    }
+}
+
+#[test]
+fn test_is_gnss() {
+    let ts = TimeScale::GPST;
+    assert_eq!(ts.is_gnss(), true);
+    let ts = TimeScale::GST;
+    assert_eq!(ts.is_gnss(), true);
+    let ts = TimeScale::UTC;
+    assert_eq!(ts.is_gnss(), false);
+    let ts = TimeScale::TAI;
+    assert_eq!(ts.is_gnss(), false);
+}

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -35,11 +35,11 @@ fn test_from_str() {
 #[test]
 fn test_is_gnss() {
     let ts = TimeScale::GPST;
-    assert_eq!(ts.is_gnss(), true);
+    assert!(ts.is_gnss());
     let ts = TimeScale::GST;
-    assert_eq!(ts.is_gnss(), true);
+    assert!(ts.is_gnss());
     let ts = TimeScale::UTC;
-    assert_eq!(ts.is_gnss(), false);
+    assert!(!ts.is_gnss());
     let ts = TimeScale::TAI;
-    assert_eq!(ts.is_gnss(), false);
+    assert!(!ts.is_gnss());
 }


### PR DESCRIPTION
* implement fmt::Display for TimeScale enum
* implement special 0x format for GNSS timescales
* introduce a testbench

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>