### PR TITLE
epoch: derive Hash

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -53,7 +53,7 @@ pub const NANOSECONDS_PER_CENTURY: u64 = DAYS_PER_CENTURY_U64 * NANOSECONDS_PER_
 /// That difference is exactly 1 nanoseconds, where the former duration is "closer to zero" than the latter.
 /// As such, the largest negative duration that can be represented sets the centuries to i16::MAX and its nanoseconds to NANOSECONDS_PER_CENTURY.
 /// 2. It was also decided that opposite durations are equal, e.g. -15 minutes == 15 minutes. If the direction of time matters, use the signum function.
-#[derive(Clone, Copy, Debug, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, Debug, PartialOrd, Eq, Ord, Hash)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct Duration {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -19,6 +19,7 @@ use core::cmp::Ordering;
 use core::convert::TryInto;
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use core::hash::{Hash, Hasher};
 
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer};
@@ -53,7 +54,7 @@ pub const NANOSECONDS_PER_CENTURY: u64 = DAYS_PER_CENTURY_U64 * NANOSECONDS_PER_
 /// That difference is exactly 1 nanoseconds, where the former duration is "closer to zero" than the latter.
 /// As such, the largest negative duration that can be represented sets the centuries to i16::MAX and its nanoseconds to NANOSECONDS_PER_CENTURY.
 /// 2. It was also decided that opposite durations are equal, e.g. -15 minutes == 15 minutes. If the direction of time matters, use the signum function.
-#[derive(Clone, Copy, Debug, PartialOrd, Eq, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialOrd, Eq, Ord)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct Duration {
@@ -79,6 +80,13 @@ impl PartialEq for Duration {
         } else {
             false
         }
+    }
+}
+
+impl Hash for Duration {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.centuries.hash(hasher);
+        self.nanoseconds.hash(hasher);
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -18,8 +18,8 @@ extern crate core;
 use core::cmp::Ordering;
 use core::convert::TryInto;
 use core::fmt;
-use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 use core::hash::{Hash, Hasher};
+use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer};

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -155,7 +155,7 @@ const CUMULATIVE_DAYS_FOR_MONTH: [u16; 12] = {
 /// Defines a nanosecond-precision Epoch.
 ///
 /// Refer to the appropriate functions for initializing this Epoch from different time systems or representations.
-#[derive(Copy, Clone, Eq)]
+#[derive(Copy, Clone, Eq, Hash)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct Epoch {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::fmt;
+use core::hash::{Hash, Hasher};
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::ParsingErrors;
@@ -155,7 +156,7 @@ const CUMULATIVE_DAYS_FOR_MONTH: [u16; 12] = {
 /// Defines a nanosecond-precision Epoch.
 ///
 /// Refer to the appropriate functions for initializing this Epoch from different time systems or representations.
-#[derive(Copy, Clone, Eq, Hash)]
+#[derive(Copy, Clone, Eq)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct Epoch {
@@ -247,6 +248,12 @@ impl AddAssign<Duration> for Epoch {
 impl PartialEq for Epoch {
     fn eq(&self, other: &Self) -> bool {
         self.duration_since_j1900_tai == other.duration_since_j1900_tai
+    }
+}
+
+impl Hash for Epoch {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.duration_since_j1900_tai.hash(hasher);
     }
 }
 

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -52,7 +52,7 @@ pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
 });
 
 /// Enum of the different time systems available
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TimeScale {


### PR DESCRIPTION
Hash is required if we want structures like "HashMap" or "BTreeMap"
indexed by an Epoch

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>