### PR TITLE
epoch, timescale: implement default trait

### DIFF
--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -156,7 +156,7 @@ const CUMULATIVE_DAYS_FOR_MONTH: [u16; 12] = {
 /// Defines a nanosecond-precision Epoch.
 ///
 /// Refer to the appropriate functions for initializing this Epoch from different time systems or representations.
-#[derive(Copy, Clone, Eq)]
+#[derive(Copy, Clone, Eq, Default)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 pub struct Epoch {

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -74,6 +74,18 @@ pub enum TimeScale {
     BDT,
 }
 
+impl Default for TimeScale {
+    /// Builds default TAI time scale
+    fn default() -> Self {
+        /*
+         * We use TAI as default Time scale,
+         * because `Epoch` is always defined with respect to TAI.
+         * Also, a default `Epoch` is then a null duration into TAI.
+         */
+        Self::TAI
+    }
+}
+
 impl TimeScale {
     pub(crate) const fn formatted_len(&self) -> usize {
         match &self {

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -54,3 +54,8 @@ fn test_is_gnss() {
     let ts = TimeScale::TAI;
     assert!(!ts.is_gnss());
 }
+
+#[test]
+fn test_default() {
+    assert_eq!(TimeScale::default(), TimeScale::TAI);
+}


### PR DESCRIPTION
Hello @ChristopherRabotin,

I just noticed we don't have a default constructor for these, while it is correctly defined for `Duration`.