### PR TITLE
Extend formal verification

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -37,7 +37,7 @@ jobs:
           # Remove `cdylib` from targets in Cargo.toml because it confuses Kani
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
-          cargo kani | cargo kani --visualize # Re-run for artifacts if it has failed.
+          cargo kani | (cargo kani --visualize && exit 1) # Re-run for artifacts if it has failed.
 
       - name: Save formal verification artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -37,11 +37,11 @@ jobs:
           # Remove `cdylib` from targets in Cargo.toml because it confuses Kani
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
-          cargo kani --visualize
-          cargo kani # Shows the result in stdout
+          cargo kani | cargo kani --visualize # Re-run for artifacts if it has failed.
 
       - name: Save formal verification artifacts
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: formal-verification-report
           path: target/report*/html/**/*

--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -37,8 +37,8 @@ jobs:
           # Remove `cdylib` from targets in Cargo.toml because it confuses Kani
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
-          cargo kani # Shows the result in stdout
           cargo kani --visualize
+          cargo kani # Shows the result in stdout
 
       - name: Save formal verification artifacts
         uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["*.tar.gz"]
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+# crate-type = ["cdylib", "rlib"]
 name = "hifitime"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["*.tar.gz"]
 edition = "2021"
 
 [lib]
-# crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 name = "hifitime"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ In order to provide full interoperability with NAIF, hifitime uses the NAIF algo
 
 # Changelog
 
+## 3.8.0
+Thanks again to [@gwbres](https://github.com/gwbres) for his work in this release!
+
++ Fix CI of the formal verification and upload artifacts, cf. [#179](https://github.com/nyx-space/hifitime/pull/179)
++ Introduce time of week construction and conversion by [@gwbres](https://github.com/gwbres), cf.[#180](https://github.com/nyx-space/hifitime/pull/180) and [#188](https://github.com/nyx-space/hifitime/pull/188)
++ Fix minor typo in `src/timeunits.rs` by [@gwbres](https://github.com/gwbres), cf. [#189](https://github.com/nyx-space/hifitime/pull/189)
++ Significantly extend formal verification of `Duration` and `Epoch`, and introduce `kani::Arbitrary` to `Duration` and `Epoch` for others to formally verify their use of time, cf. [#192](https://github.com/nyx-space/hifitime/pull/192)
+
 ## 3.7.0
 Huge thanks to [@gwbres](https://github.com/gwbres) who put in all of the work for this release. These usability changes allow [Rinex](https://crates.io/crates/rinex) to use hifitime, check out this work.
 + timescale.rs: derive serdes traits when feasible by @gwbres in https://github.com/nyx-space/hifitime/pull/167

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -282,13 +282,13 @@ impl Duration {
             let rem_nanos = self.nanoseconds.rem_euclid(NANOSECONDS_PER_CENTURY);
 
             if self.centuries == i16::MIN {
-                if rem_nanos > Self::MIN.nanoseconds {
+                if rem_nanos + self.nanoseconds > Self::MIN.nanoseconds {
                     // We're at the min number of centuries already, and we have extra nanos, so we're saturated the duration limit
                     *self = Self::MIN;
                 }
                 // Else, we're near the MIN but we're within the MIN in nanoseconds, so let's not do anything here.
             } else if self.centuries == i16::MAX {
-                if rem_nanos > Self::MAX.nanoseconds {
+                if rem_nanos + self.nanoseconds > Self::MAX.nanoseconds {
                     // Saturated max
                     *self = Self::MAX;
                 }
@@ -614,7 +614,7 @@ impl Duration {
     /// Maximum duration that can be represented
     pub const MAX: Self = Self {
         centuries: i16::MAX,
-        nanoseconds: 2 * NANOSECONDS_PER_CENTURY,
+        nanoseconds: NANOSECONDS_PER_CENTURY,
     };
 
     /// Minimum duration that can be represented
@@ -1001,14 +1001,7 @@ impl Sub for Duration {
                 };
                 me.nanoseconds = me.nanoseconds + NANOSECONDS_PER_CENTURY - rhs.nanoseconds;
             }
-            Some(nanos) => {
-                if self.centuries >= 0 && rhs.centuries < 0 {
-                    // Account for zero crossing
-                    me.nanoseconds = nanos + 1
-                } else {
-                    me.nanoseconds = nanos
-                }
-            }
+            Some(nanos) => me.nanoseconds = nanos,
         };
 
         me.normalize();
@@ -1256,7 +1249,7 @@ fn test_bounds() {
 
     let max = Duration::MAX;
     assert_eq!(max.centuries, i16::MAX);
-    assert_eq!(max.nanoseconds, 2 * NANOSECONDS_PER_CENTURY);
+    assert_eq!(max.nanoseconds, NANOSECONDS_PER_CENTURY);
 
     let min_p = Duration::MIN_POSITIVE;
     assert_eq!(min_p.centuries, 0);
@@ -1272,7 +1265,7 @@ fn test_bounds() {
 
     let max_n1 = Duration::MAX - 1 * Unit::Nanosecond;
     assert_eq!(max_n1.centuries, i16::MAX);
-    assert_eq!(max_n1.nanoseconds, 2 * NANOSECONDS_PER_CENTURY - 1);
+    assert_eq!(max_n1.nanoseconds, NANOSECONDS_PER_CENTURY - 1);
 }
 
 #[cfg(kani)]

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1420,16 +1420,16 @@ fn formal_duration_truncated_ns_reciprocity() {
     }
 }
 
-#[cfg(kani)]
-#[kani::proof]
-// #[test]
+// #[cfg(kani)]
+// #[kani::proof]
+#[test]
 fn formal_duration_seconds() {
-    let seconds: f64 = kani::any();
-    // let seconds =
-    //     f64::from_bits(0b01000000010111111011010000110111101001100000110111100000_00000001);
+    // let seconds: f64 = kani::any();
+    let seconds =
+        f64::from_bits(0b01000000010111111011010000110111101001100000110111100000_00000001);
 
-    kani::assume(seconds > 1e-9);
-    kani::assume(seconds < 1e14);
+    // kani::assume(seconds > 1e-9);
+    // kani::assume(seconds < 1e14);
 
     if seconds.is_finite() {
         let big_seconds = seconds * 1e9;

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1170,7 +1170,7 @@ impl Epoch {
 
             (
                 year,
-                month as u8,
+                month,
                 day as u8,
                 hours as u8,
                 minutes as u8,
@@ -1182,7 +1182,7 @@ impl Epoch {
         } else {
             (
                 year,
-                month as u8,
+                month,
                 day as u8,
                 hours as u8,
                 minutes as u8,
@@ -2266,13 +2266,12 @@ impl Epoch {
     /// This is usually how GNSS receivers describe a timestamp.
     pub fn to_time_of_week(&self) -> (u32, u64) {
         let total_nanoseconds = self.to_duration().total_nanoseconds();
-        let weeks =
-            total_nanoseconds / NANOSECONDS_PER_DAY as i128 / Weekday::DAYS_PER_WEEK_I128 as i128;
+        let weeks = total_nanoseconds / NANOSECONDS_PER_DAY as i128 / Weekday::DAYS_PER_WEEK_I128;
         // elapsed nanoseconds in current week:
         //   remove previously determined nb of weeks
         //   get residual nanoseconds
-        let nanoseconds = total_nanoseconds
-            - weeks * NANOSECONDS_PER_DAY as i128 * Weekday::DAYS_PER_WEEK_I128 as i128;
+        let nanoseconds =
+            total_nanoseconds - weeks * NANOSECONDS_PER_DAY as i128 * Weekday::DAYS_PER_WEEK_I128;
         (weeks as u32, nanoseconds as u64)
     }
 
@@ -2982,7 +2981,7 @@ fn formal_epoch_from_time_scale() {
     let time_scale: TimeScale = TimeScale::TDB;
     let epoch: Epoch = Epoch::from_duration(duration, time_scale);
     assert!(
-        (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 150 * Unit::Nanosecond
+        (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 250 * Unit::Nanosecond
     );
 
     // Skip UTC, kani chokes on the leap seconds counting.

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2971,6 +2971,17 @@ fn formal_epoch_reciprocity_tai() {
     let time_scale: TimeScale = TimeScale::TAI;
     let epoch: Epoch = Epoch::from_duration(duration, time_scale);
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+
+    // Check that no error occurs on initialization
+    let seconds: f64 = kani::any();
+    if seconds.is_finite() {
+        Epoch::from_tai_seconds(seconds);
+    }
+
+    let days: f64 = kani::any();
+    if days.is_finite() {
+        Epoch::from_tai_days(days);
+    }
 }
 
 #[cfg(kani)]
@@ -2986,8 +2997,18 @@ fn formal_epoch_reciprocity_tt() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+
+    // Check that no error occurs on initialization
+    let seconds: f64 = kani::any();
+    if seconds.is_finite() {
+        Epoch::from_tt_seconds(seconds);
+    }
+    // No TT Days initializer
 }
 
+// Skip ET, kani chokes on the Newton Raphson loop.
+
+// Skip TDB
 // #[cfg(kani)]
 // #[kani::proof]
 #[test]
@@ -3015,13 +3036,12 @@ fn formal_epoch_reciprocity_tdb() {
     }
 }
 
+// Skip UTC, kani chokes on the leap seconds counting.
+
 #[cfg(kani)]
 #[kani::proof]
 fn formal_epoch_reciprocity_gpst() {
     let duration: Duration = kani::any();
-
-    // Skip UTC, kani chokes on the leap seconds counting.
-    // Skip ET, kani chokes on the Newton Raphson loop.
 
     // GPST
     let time_scale: TimeScale = TimeScale::GPST;
@@ -3030,6 +3050,14 @@ fn formal_epoch_reciprocity_gpst() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+
+    // Check that no error occurs on initialization
+    let seconds: f64 = kani::any();
+    if seconds.is_finite() {
+        Epoch::from_gpst_seconds(seconds);
+    }
+
+    Epoch::from_gpst_nanoseconds(kani::any());
 }
 
 #[cfg(kani)]
@@ -3044,6 +3072,19 @@ fn formal_epoch_reciprocity_gst() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+
+    // Check that no error occurs on initialization
+    let seconds: f64 = kani::any();
+    if seconds.is_finite() {
+        Epoch::from_gst_seconds(seconds);
+    }
+
+    let days: f64 = kani::any();
+    if days.is_finite() {
+        Epoch::from_gst_days(days);
+    }
+
+    Epoch::from_gst_nanoseconds(kani::any());
 }
 
 #[cfg(kani)]
@@ -3058,18 +3099,28 @@ fn formal_epoch_reciprocity_bdt() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+
+    // Check that no error occurs on initialization
+    let seconds: f64 = kani::any();
+    if seconds.is_finite() {
+        Epoch::from_bdt_seconds(seconds);
+    }
+
+    let days: f64 = kani::any();
+    if days.is_finite() {
+        Epoch::from_bdt_days(days);
+    }
+
+    Epoch::from_bdt_nanoseconds(kani::any());
 }
 
 #[cfg(kani)]
 #[kani::proof]
-fn formal_epoch_in_days() {
+fn formal_epoch_julian() {
     let days: f64 = kani::any();
 
     if days.is_finite() {
         // The initializers will fail on subnormal days.
-        Epoch::from_bdt_days(days);
-        Epoch::from_tai_days(days);
-        Epoch::from_gst_days(days);
         Epoch::from_mjd_bdt(days);
         Epoch::from_mjd_gpst(days);
         Epoch::from_mjd_gst(days);
@@ -3080,23 +3131,5 @@ fn formal_epoch_in_days() {
         Epoch::from_jde_tai(days);
         Epoch::from_jde_et(days);
         Epoch::from_jde_tai(days);
-        // NOTE: We cannot test the UTC initializers because kani seems to fail on the leap second counting loop.
-    }
-}
-
-#[cfg(kani)]
-#[kani::proof]
-fn formal_epoch_in_seconds() {
-    let seconds: f64 = kani::any();
-
-    if seconds.is_finite() {
-        // The initializers will fail on subnormal days.
-        Epoch::from_bdt_seconds(seconds);
-        Epoch::from_tt_seconds(seconds);
-        Epoch::from_et_seconds(seconds);
-        Epoch::from_tdb_seconds(seconds);
-        Epoch::from_tai_seconds(seconds);
-        Epoch::from_gst_seconds(seconds);
-        Epoch::from_gpst_seconds(seconds);
     }
 }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2962,10 +2962,12 @@ fn test_serdes() {
     assert_eq!(e, parsed);
 }
 
-#[cfg(kani)]
-#[kani::proof]
+// #[cfg(kani)]
+// #[kani::proof]
+// #[test]
 fn formal_epoch_from_time_scale() {
-    let duration: Duration = kani::any();
+    // let duration: Duration = kani::any();
+    let duration = Duration::from_parts(-32767, 0);
 
     // TAI
     let time_scale: TimeScale = TimeScale::TAI;
@@ -2975,14 +2977,23 @@ fn formal_epoch_from_time_scale() {
     // TT
     let time_scale: TimeScale = TimeScale::TT;
     let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    println!(
+        "got: {}\nexp: {}",
+        epoch.to_duration_in_time_scale(time_scale),
+        duration
+    );
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
 
-    // TDB
-    let time_scale: TimeScale = TimeScale::TDB;
-    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    assert!(
-        (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 250 * Unit::Nanosecond
-    );
+    // // TDB
+    // let time_scale: TimeScale = TimeScale::TDB;
+    // let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    // println!(
+    //     "{}",
+    //     (epoch.to_duration_in_time_scale(time_scale) - duration)
+    // );
+    // assert!(
+    //     (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 250 * Unit::Nanosecond
+    // );
 
     // Skip UTC, kani chokes on the leap seconds counting.
     // Skip ET, kani chokes on the Newton Raphson loop.

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2993,7 +2993,7 @@ fn formal_epoch_reciprocity_tt() {
 // #[test]
 fn formal_epoch_reciprocity_tdb() {
     let duration: Duration = kani::any();
-    // let duration = Duration::from_parts(0, 3124417376255567750);
+    // let duration = Duration::from_parts(19510, 3155759999999997938);
 
     // TDB
     let ts_offset = TimeScale::TDB.ref_epoch() - TimeScale::TAI.ref_epoch();
@@ -3004,9 +3004,14 @@ fn formal_epoch_reciprocity_tdb() {
 
         let time_scale: TimeScale = TimeScale::TDB;
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-        let error = (epoch.to_duration_in_time_scale(time_scale) - duration).abs();
-        assert_eq!(error.centuries, 0);
-        assert!(error.nanoseconds < 500_000); // 500 μs
+        let out_duration = epoch.to_duration_in_time_scale(time_scale);
+        assert_eq!(out_duration.centuries, duration.centuries);
+        if out_duration.nanoseconds > duration.nanoseconds {
+            assert!(out_duration.nanoseconds - duration.nanoseconds < 500_000);
+        } else if out_duration.nanoseconds < duration.nanoseconds {
+            assert!(duration.nanoseconds - out_duration.nanoseconds < 500_000);
+        }
+        // Else: they match and we're happy.
     }
 }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2962,12 +2962,12 @@ fn test_serdes() {
     assert_eq!(e, parsed);
 }
 
-#[cfg(kani)]
-#[kani::proof]
-// #[test]
+// #[cfg(kani)]
+// #[kani::proof]
+#[test]
 fn formal_epoch_from_time_scale() {
-    let duration: Duration = kani::any();
-    // let duration = Duration::from_parts(32767, 2966457567000000000);
+    // let duration: Duration = kani::any();
+    let duration = Duration::from_parts(-32767, 0);
 
     // TAI
     let time_scale: TimeScale = TimeScale::TAI;

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2962,3 +2962,16 @@ fn test_serdes() {
     let parsed: Epoch = serde_json::from_str(content).unwrap();
     assert_eq!(e, parsed);
 }
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_from_time_scale() {
+    let duration: Duration = kani::any();
+    let time_scale: TimeScale = kani::any();
+
+    if time_scale != TimeScale::UTC && time_scale != TimeScale::BDT && time_scale != TimeScale::GST
+    {
+        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    }
+}

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -157,7 +157,7 @@ const CUMULATIVE_DAYS_FOR_MONTH: [u16; 12] = {
 
 /// Defines a nanosecond-precision Epoch.
 ///
-/// Refer to the appropriate functions for initializing this Epoch from different time systems or representations.
+/// Refer to the appropriate functions for initializing this Epoch from different time scales or representations.
 #[derive(Copy, Clone, Eq, Default)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
@@ -514,7 +514,7 @@ impl Epoch {
 
     #[must_use]
     /// Initialize an Epoch from Dynamic Barycentric Time (TDB) seconds past 2000 JAN 01 midnight (difference than SPICE)
-    /// NOTE: This uses the ESA algorithm, which is a notch more complicaste than the SPICE algorithm, but more precise.
+    /// NOTE: This uses the ESA algorithm, which is a notch more complicated than the SPICE algorithm, but more precise.
     /// In fact, SPICE algorithm is precise +/- 30 microseconds for a century whereas ESA algorithm should be exactly correct.
     pub fn from_tdb_seconds(seconds_j2000: f64) -> Epoch {
         assert!(
@@ -652,7 +652,7 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Initialize an Epoch from the provided UNIX milisecond timestamp since UTC midnight 1970 January 01.
+    /// Initialize an Epoch from the provided UNIX millisecond timestamp since UTC midnight 1970 January 01.
     pub fn from_unix_milliseconds(millisecond: f64) -> Self {
         Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + millisecond * Unit::Millisecond)
     }
@@ -679,8 +679,8 @@ impl Epoch {
         )
     }
 
-    /// Attempts to build an Epoch from the provided Gregorian date and time in the provided time system.
-    /// NOTE: If the timesystem is TDB, this function assumes that the SPICE format is used
+    /// Attempts to build an Epoch from the provided Gregorian date and time in the provided time scale.
+    /// NOTE: If the time scale is TDB, this function assumes that the SPICE format is used
     #[allow(clippy::too_many_arguments)]
     pub fn maybe_from_gregorian(
         year: i32,
@@ -772,7 +772,7 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Initialize from the Gregoerian date at midnight in TAI.
+    /// Initialize from the Gregorian date at midnight in TAI.
     pub fn from_gregorian_tai_at_midnight(year: i32, month: u8, day: u8) -> Self {
         Self::maybe_from_gregorian_tai(year, month, day, 0, 0, 0, 0)
             .expect("invalid Gregorian date")
@@ -866,7 +866,7 @@ impl Epoch {
 
     #[allow(clippy::too_many_arguments)]
     #[must_use]
-    /// Builds an Epoch from the provided Gregorian date and time in the provided time system. If invalid date is provided, this function will panic.
+    /// Builds an Epoch from the provided Gregorian date and time in the provided time scale. If invalid date is provided, this function will panic.
     /// Use maybe_from_gregorian if unsure.
     pub fn from_gregorian(
         year: i32,
@@ -916,15 +916,15 @@ impl Epoch {
             .expect("invalid Gregorian date")
     }
 
-    /// Converts a Gregorian date time in ISO8601 or RFC3339 format into an Epoch, accounting for the time zone designator and the time system.
+    /// Converts a Gregorian date time in ISO8601 or RFC3339 format into an Epoch, accounting for the time zone designator and the time scale.
     ///
     /// # Definition
     /// 1. Time Zone Designator: this is either a `Z` (lower or upper case) to specify UTC, or an offset in hours and minutes off of UTC, such as `+01:00` for UTC plus one hour and zero minutes.
     /// 2. Time system (or time "scale"): UTC, TT, TAI, TDB, ET, etc.
     ///
     /// Converts an ISO8601 or RFC3339 datetime representation to an Epoch.
-    /// If no time system is specified, then UTC is assumed.
-    /// A time system may be specified _in addition_ to the format unless
+    /// If no time scale is specified, then UTC is assumed.
+    /// A time scale may be specified _in addition_ to the format unless
     /// The `T` which separates the date from the time can be replaced with a single whitespace character (`\W`).
     /// The offset is also optional, cf. the examples below.
     ///
@@ -1507,8 +1507,8 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    /// Attempts to build an Epoch from the provided Gregorian date and time in the provided time system.
-    /// NOTE: If the timesystem is TDB, this function assumes that the SPICE format is used
+    /// Attempts to build an Epoch from the provided Gregorian date and time in the provided time scale.
+    /// NOTE: If the time scale is TDB, this function assumes that the SPICE format is used
     #[allow(clippy::too_many_arguments)]
     fn maybe_init_from_gregorian(
         year: i32,
@@ -1541,7 +1541,7 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[staticmethod]
-    /// Initialize from the Gregoerian date at midnight in TAI.
+    /// Initialize from the Gregorian date at midnight in TAI.
     fn init_from_gregorian_tai_at_midnight(year: i32, month: u8, day: u8) -> Self {
         Self::from_gregorian_tai_at_midnight(year, month, day)
     }
@@ -1858,7 +1858,7 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Returns the centuries pased J2000 TT
+    /// Returns the centuries passed J2000 TT
     pub fn to_tt_centuries_j2k(&self) -> f64 {
         (self.to_tt_duration() - Unit::Second * ET_EPOCH_S).to_unit(Unit::Century)
     }
@@ -2212,7 +2212,7 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Ceils this epoch to the closest provided duration in the TAI time system
+    /// Ceils this epoch to the closest provided duration in the TAI time scale
     ///
     /// # Example
     /// ```
@@ -2509,7 +2509,7 @@ impl Epoch {
 
     #[cfg(feature = "std")]
     #[must_use]
-    /// Converts the Epoch to Gregorian in the provided time system and in the ISO8601 format with the time system appended to the string
+    /// Converts the Epoch to Gregorian in the provided time scale and in the ISO8601 format with the time scale appended to the string
     pub fn to_gregorian_str(&self, time_scale: TimeScale) -> String {
         let (y, mm, dd, hh, min, s, nanos) = Self::compute_gregorian(match time_scale {
             TimeScale::TT => self.to_tt_duration(),
@@ -2874,7 +2874,7 @@ pub const fn is_gregorian_valid(
 }
 
 /// `is_leap_year` returns whether the provided year is a leap year or not.
-/// Tests for this function are part of the Datetime testime_scale.
+/// Tests for this function are part of the Datetime tests.
 const fn is_leap_year(year: i32) -> bool {
     (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }
@@ -2967,11 +2967,80 @@ fn test_serdes() {
 #[kani::proof]
 fn formal_epoch_from_time_scale() {
     let duration: Duration = kani::any();
-    let time_scale: TimeScale = kani::any();
 
-    if time_scale != TimeScale::UTC && time_scale != TimeScale::BDT && time_scale != TimeScale::GST
-    {
-        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    // TAI
+    let time_scale: TimeScale = TimeScale::TAI;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+
+    // TT
+    let time_scale: TimeScale = TimeScale::TT;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+
+    // TDB
+    let time_scale: TimeScale = TimeScale::TDB;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert!(
+        (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 150 * Unit::Nanosecond
+    );
+
+    // Skip UTC, kani chokes on the leap seconds counting.
+    // Skip ET, kani chokes on the Newton Raphson loop.
+
+    // GPST
+    let time_scale: TimeScale = TimeScale::GPST;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+
+    // GST
+    let time_scale: TimeScale = TimeScale::GST;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+
+    // BDT
+    let time_scale: TimeScale = TimeScale::BDT;
+    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_in_days() {
+    let days: f64 = kani::any();
+
+    if days.is_finite() {
+        // The initializers will fail on subnormal days.
+        Epoch::from_bdt_days(days);
+        Epoch::from_tai_days(days);
+        Epoch::from_gst_days(days);
+        Epoch::from_mjd_bdt(days);
+        Epoch::from_mjd_gpst(days);
+        Epoch::from_mjd_gst(days);
+        Epoch::from_mjd_tai(days);
+        Epoch::from_jde_bdt(days);
+        Epoch::from_jde_gpst(days);
+        Epoch::from_jde_gst(days);
+        Epoch::from_jde_tai(days);
+        Epoch::from_jde_et(days);
+        Epoch::from_jde_tai(days);
+        // NOTE: We cannot test the UTC initializers because kani seems to fail on the leap second counting loop.
+    }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_in_seconds() {
+    let seconds: f64 = kani::any();
+
+    if seconds.is_finite() {
+        // The initializers will fail on subnormal days.
+        Epoch::from_bdt_seconds(seconds);
+        Epoch::from_tt_seconds(seconds);
+        Epoch::from_et_seconds(seconds);
+        Epoch::from_tdb_seconds(seconds);
+        Epoch::from_tai_seconds(seconds);
+        Epoch::from_gst_seconds(seconds);
+        Epoch::from_gpst_seconds(seconds);
     }
 }

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2988,12 +2988,12 @@ fn formal_epoch_reciprocity_tt() {
     }
 }
 
-#[cfg(kani)]
-#[kani::proof]
-// #[test]
+// #[cfg(kani)]
+// #[kani::proof]
+#[test]
 fn formal_epoch_reciprocity_tdb() {
-    let duration: Duration = kani::any();
-    // let duration = Duration::from_parts(19510, 3155759999999997938);
+    // let duration: Duration = kani::any();
+    let duration = Duration::from_parts(19510, 3155759999999997938);
 
     // TDB
     let ts_offset = TimeScale::TDB.ref_epoch() - TimeScale::TAI.ref_epoch();

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2967,7 +2967,7 @@ fn test_serdes() {
 // #[test]
 fn formal_epoch_from_time_scale() {
     let duration: Duration = kani::any();
-    // let duration = Duration::from_parts(-32766, 0);
+    // let duration = Duration::from_parts(32767, 2966457567000000000);
 
     // TAI
     let time_scale: TimeScale = TimeScale::TAI;
@@ -2980,9 +2980,8 @@ fn formal_epoch_from_time_scale() {
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
 
     // TDB
-    if duration > Duration::MIN + (1 * Unit::Century + 12 * Unit::Hour)
-        && duration < Duration::MAX - (1 * Unit::Century + 12 * Unit::Hour)
-    {
+    let ts_offset = TimeScale::TDB.ref_epoch() - TimeScale::TAI.ref_epoch();
+    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
         // We guard TDB from durations that are would hit the MIN or the MAX.
         // TDB is centered on J2000 but the Epoch is on J1900. So on initialization, we offset by one century and twelve hours.
         // If the duration is too close to the Duration bounds, then the TDB initialization and retrieval will fail (because the bounds will have been hit).
@@ -2999,18 +2998,27 @@ fn formal_epoch_from_time_scale() {
 
     // GPST
     let time_scale: TimeScale = TimeScale::GPST;
-    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    let ts_offset = TimeScale::GPST.ref_epoch() - TimeScale::TAI.ref_epoch();
+    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
+        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    }
 
     // GST
     let time_scale: TimeScale = TimeScale::GST;
-    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    let ts_offset = TimeScale::GST.ref_epoch() - TimeScale::TAI.ref_epoch();
+    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
+        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    }
 
     // BDT
     let time_scale: TimeScale = TimeScale::BDT;
-    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    let ts_offset = TimeScale::BDT.ref_epoch() - TimeScale::TAI.ref_epoch();
+    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
+        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    }
 }
 
 #[cfg(kani)]

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2964,23 +2964,36 @@ fn test_serdes() {
 
 #[cfg(kani)]
 #[kani::proof]
-// #[test]
-fn formal_epoch_from_time_scale() {
+fn formal_epoch_reciprocity_tai() {
     let duration: Duration = kani::any();
-    // let duration = Duration::from_parts(-1, 0);
 
     // TAI
     let time_scale: TimeScale = TimeScale::TAI;
     let epoch: Epoch = Epoch::from_duration(duration, time_scale);
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+}
 
-    // TT
-    let ts_offset = TimeScale::TT.ref_epoch() - TimeScale::TAI.ref_epoch();
-    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_reciprocity_tt() {
+    let duration: Duration = kani::any();
+
+    // TT -- Check valid within bounds of (MIN + TT Offset) and (MAX - TT Offset)
+    if duration > Duration::MIN + TT_OFFSET_MS * Unit::Millisecond
+        && duration < Duration::MAX - TT_OFFSET_MS * Unit::Millisecond
+    {
         let time_scale: TimeScale = TimeScale::TT;
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+// #[test]
+fn formal_epoch_reciprocity_tdb() {
+    let duration: Duration = kani::any();
+    // let duration = Duration::from_parts(0, 3124417376255567750);
 
     // TDB
     let ts_offset = TimeScale::TDB.ref_epoch() - TimeScale::TAI.ref_epoch();
@@ -2991,10 +3004,16 @@ fn formal_epoch_from_time_scale() {
 
         let time_scale: TimeScale = TimeScale::TDB;
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-        assert!(
-            (epoch.to_duration_in_time_scale(time_scale) - duration).abs() < 250 * Unit::Nanosecond
-        );
+        let error = (epoch.to_duration_in_time_scale(time_scale) - duration).abs();
+        assert_eq!(error.centuries, 0);
+        assert!(error.nanoseconds < 500_000); // 500 μs
     }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_reciprocity_gpst() {
+    let duration: Duration = kani::any();
 
     // Skip UTC, kani chokes on the leap seconds counting.
     // Skip ET, kani chokes on the Newton Raphson loop.
@@ -3006,6 +3025,12 @@ fn formal_epoch_from_time_scale() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_reciprocity_gst() {
+    let duration: Duration = kani::any();
 
     // GST
     let time_scale: TimeScale = TimeScale::GST;
@@ -3014,6 +3039,12 @@ fn formal_epoch_from_time_scale() {
         let epoch: Epoch = Epoch::from_duration(duration, time_scale);
         assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
     }
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_epoch_reciprocity_bdt() {
+    let duration: Duration = kani::any();
 
     // BDT
     let time_scale: TimeScale = TimeScale::BDT;

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2962,12 +2962,12 @@ fn test_serdes() {
     assert_eq!(e, parsed);
 }
 
-// #[cfg(kani)]
-// #[kani::proof]
-#[test]
+#[cfg(kani)]
+#[kani::proof]
+// #[test]
 fn formal_epoch_from_time_scale() {
-    // let duration: Duration = kani::any();
-    let duration = Duration::from_parts(-32767, 0);
+    let duration: Duration = kani::any();
+    // let duration = Duration::from_parts(-1, 0);
 
     // TAI
     let time_scale: TimeScale = TimeScale::TAI;
@@ -2975,9 +2975,12 @@ fn formal_epoch_from_time_scale() {
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
 
     // TT
-    let time_scale: TimeScale = TimeScale::TT;
-    let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    let ts_offset = TimeScale::TT.ref_epoch() - TimeScale::TAI.ref_epoch();
+    if duration > Duration::MIN + ts_offset && duration < Duration::MAX - ts_offset {
+        let time_scale: TimeScale = TimeScale::TT;
+        let epoch: Epoch = Epoch::from_duration(duration, time_scale);
+        assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
+    }
 
     // TDB
     let ts_offset = TimeScale::TDB.ref_epoch() - TimeScale::TAI.ref_epoch();

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -2962,8 +2962,8 @@ fn test_serdes() {
     assert_eq!(e, parsed);
 }
 
-// #[cfg(kani)]
-// #[kani::proof]
+#[cfg(kani)]
+#[kani::proof]
 // #[test]
 fn formal_epoch_from_time_scale() {
     // let duration: Duration = kani::any();
@@ -2977,11 +2977,6 @@ fn formal_epoch_from_time_scale() {
     // TT
     let time_scale: TimeScale = TimeScale::TT;
     let epoch: Epoch = Epoch::from_duration(duration, time_scale);
-    println!(
-        "got: {}\nexp: {}",
-        epoch.to_duration_in_time_scale(time_scale),
-        duration
-    );
     assert_eq!(epoch.to_duration_in_time_scale(time_scale), duration);
 
     // // TDB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub const JDE_OFFSET_SECONDS: f64 = JDE_OFFSET_DAYS * SECONDS_PER_DAY;
 pub const DAYS_PER_YEAR: f64 = 365.25;
 /// `DAYS_PER_YEAR_NLD` corresponds to the number of days per year **without leap days**.
 pub const DAYS_PER_YEAR_NLD: f64 = 365.0;
-/// `DAYS_PER_CENTURY` corresponds to the number of days per centuy in the Julian calendar.
+/// `DAYS_PER_CENTURY` corresponds to the number of days per century in the Julian calendar.
 pub const DAYS_PER_CENTURY: f64 = 36525.0;
 pub const DAYS_PER_CENTURY_I64: i64 = 36525;
 /// `SECONDS_PER_MINUTE` defines the number of seconds per minute.
@@ -51,8 +51,14 @@ pub const SECONDS_PER_YEAR: f64 = 31_557_600.0;
 pub const SECONDS_PER_YEAR_I64: i64 = 31_557_600;
 /// `SECONDS_PER_TROPICAL_YEAR` corresponds to the number of seconds per tropical year from [NAIF SPICE](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/tyear_c.html).
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
-/// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sideral year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
+/// `SECONDS_PER_SIDERAL_YEAR` corresponds to the number of seconds per sidereal year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
+#[deprecated(
+    since = "3.8.0",
+    note = "Use SECONDS_PER_SIDEREAL_YEAR instead (does not have the typo)"
+)]
 pub const SECONDS_PER_SIDERAL_YEAR: f64 = 31_558_150.0;
+/// `SECONDS_PER_SIDEREAL_YEAR` corresponds to the number of seconds per sidereal year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
+pub const SECONDS_PER_SIDEREAL_YEAR: f64 = 31_558_150.0;
 
 /// The duration between J2000 and J1900: one century **minus** twelve hours. J1900 starts at _noon_ but J2000 is at midnight.
 pub const J2000_TO_J1900_DURATION: Duration = Duration {
@@ -138,7 +144,7 @@ pub enum Errors {
     ParseError(ParsingErrors),
     /// Raised when trying to initialize an Epoch or Duration from its hi and lo values, but these overlap
     ConversionOverlapError(f64, f64),
-    /// Raised if an overflow occured
+    /// Raised if an overflow occurred
     Overflow,
     /// Raised if the initialization from system time failed
     SystemTimeError,
@@ -167,7 +173,7 @@ impl fmt::Display for Errors {
             }
             Self::Overflow => write!(
                 f,
-                "overflow occured when trying to convert Duration information"
+                "overflow occurred when trying to convert Duration information"
             ),
             Self::SystemTimeError => write!(f, "std::time::SystemTime returned an error"),
         }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -34,7 +34,7 @@ pub const J2000_REF_EPOCH: Epoch = Epoch::from_tai_duration(J2000_TO_J1900_DURAT
 /// GPS reference epoch is UTC midnight between 05 January and 06 January 1980; cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>.
 pub const GPST_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
     centuries: 0,
-    nanoseconds: 2_524_953_619_000_000_000,
+    nanoseconds: 2_524_953_619_000_000_000, // XXX
 });
 pub const SECONDS_GPS_TAI_OFFSET: f64 = 2_524_953_619.0;
 pub const SECONDS_GPS_TAI_OFFSET_I64: i64 = 2_524_953_619;

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -14,6 +14,9 @@ use pyo3::prelude::*;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 
+#[cfg(kani)]
+use kani::Arbitrary;
+
 use core::fmt;
 use core::str::FromStr;
 
@@ -81,6 +84,16 @@ pub enum TimeScale {
     GST,
     /// BeiDou Time scale
     BDT,
+}
+
+#[cfg(kani)]
+impl Arbitrary for TimeScale {
+    #[inline(always)]
+    fn any() -> Self {
+        let ts_u8: u8 = kani::any();
+
+        Self::from(ts_u8)
+    }
 }
 
 impl Default for TimeScale {
@@ -229,4 +242,10 @@ fn test_serdes() {
     assert_eq!(content, serde_json::to_string(&ts).unwrap());
     let parsed: TimeScale = serde_json::from_str(content).unwrap();
     assert_eq!(ts, parsed);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+fn formal_time_scale() {
+    let _time_scale: TimeScale = kani::any();
 }

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -154,7 +154,7 @@ impl fmt::Display for TimeScale {
 
 impl fmt::LowerHex for TimeScale {
     /// Prints given TimeScale in RINEX format
-    /// ie., standard GNSS constellation name is prefered when possible
+    /// ie., standard GNSS constellation name is preferred when possible
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::GPST => write!(f, "GPS"),

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -247,10 +247,10 @@ impl Mul<i64> for Unit {
 
         match q.checked_mul(factor) {
             Some(total_ns) => {
-                if total_ns.abs() < (i64::MAX as i64) {
-                    Duration::from_truncated_nanoseconds(total_ns as i64)
+                if total_ns.abs() < i64::MAX {
+                    Duration::from_truncated_nanoseconds(total_ns)
                 } else {
-                    Duration::from_total_nanoseconds(total_ns as i128)
+                    Duration::from_total_nanoseconds(i128::from(total_ns))
                 }
             }
             None => {

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,5 +1,6 @@
 use hifitime::{
-    Duration, Errors, Freq, Frequencies, ParsingErrors, TimeUnits, Unit, NANOSECONDS_PER_MINUTE,
+    Duration, Errors, Freq, Frequencies, ParsingErrors, TimeUnits, Unit, NANOSECONDS_PER_CENTURY,
+    NANOSECONDS_PER_MINUTE,
 };
 
 #[cfg(feature = "std")]
@@ -222,6 +223,14 @@ fn test_ops_near_bounds() {
     assert_eq!(
         (Duration::MIN + 1 * Unit::Nanosecond) - (Duration::MIN + 1 * Unit::Nanosecond),
         0 * Unit::Century
+    );
+
+    let tt_offset_ns: u64 = 32_184_000_000;
+    let duration = Duration::from_parts(-32767, 0);
+    let exp = Duration::from_parts(-32768, NANOSECONDS_PER_CENTURY - tt_offset_ns);
+    assert_eq!(
+        duration - Duration::from_total_nanoseconds(tt_offset_ns.into()),
+        exp
     );
 }
 

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -161,7 +161,7 @@ fn duration_format() {
     assert_eq!(format!("{}", sum), "-35 min");
 
     assert_eq!(format!("{}", Duration::MAX), "1196851200 days");
-    assert_eq!(format!("{}", Duration::MIN), "-1196887725 days");
+    assert_eq!(format!("{}", Duration::MIN), "-1196851200 days");
     assert_eq!(format!("{}", Duration::ZERO), "0 ns");
 
     // The `e` format will print this as a floating point value.
@@ -240,8 +240,8 @@ fn test_ops_near_bounds() {
     );
 
     // Check that we saturate one way but not the other for MIN
-    assert_ne!(Duration::MIN - 1 * Unit::Nanosecond, Duration::MIN);
-    assert_eq!(Duration::MIN + 1 * Unit::Nanosecond, Duration::MIN);
+    assert_eq!(Duration::MIN - 1 * Unit::Nanosecond, Duration::MIN);
+    assert_ne!(Duration::MIN + 1 * Unit::Nanosecond, Duration::MIN);
 
     // Check that we saturate one way but not the other for MAX
     assert_eq!(Duration::MAX + 1 * Unit::Nanosecond, Duration::MAX);

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -160,7 +160,7 @@ fn duration_format() {
     assert_eq!(delta * -1.0, 0.0);
     assert_eq!(format!("{}", sum), "-35 min");
 
-    assert_eq!(format!("{}", Duration::MAX), "1196887725 days");
+    assert_eq!(format!("{}", Duration::MAX), "1196851200 days");
     assert_eq!(format!("{}", Duration::MIN), "-1196887725 days");
     assert_eq!(format!("{}", Duration::ZERO), "0 ns");
 
@@ -233,8 +233,18 @@ fn test_ops_near_bounds() {
         exp
     );
 
-    // Check that we saturate one way but not the other
-    assert_ne!(Duration::MIN + 1 * Unit::Nanosecond, Duration::MIN);
+    // Test the zero crossing with a large negative value
+    assert_eq!(
+        2 * Unit::Nanosecond - (-1 * Unit::Century),
+        1 * Unit::Century + 2 * Unit::Nanosecond
+    );
+
+    // Check that we saturate one way but not the other for MIN
+    assert_ne!(Duration::MIN - 1 * Unit::Nanosecond, Duration::MIN);
+    assert_eq!(Duration::MIN + 1 * Unit::Nanosecond, Duration::MIN);
+
+    // Check that we saturate one way but not the other for MAX
+    assert_eq!(Duration::MAX + 1 * Unit::Nanosecond, Duration::MAX);
     assert_ne!(Duration::MAX - 1 * Unit::Nanosecond, Duration::MAX);
 }
 
@@ -245,10 +255,6 @@ fn test_neg() {
     assert_eq!(2.nanoseconds(), -(2.0.nanoseconds()));
     assert_eq!(Duration::MIN, -Duration::MAX);
     assert_eq!(Duration::MAX, -Duration::MIN);
-    assert_eq!(
-        Duration::MIN + 1 * Unit::Nanosecond,
-        -(Duration::MAX - 1 * Unit::Nanosecond)
-    );
 }
 
 #[test]

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -298,6 +298,9 @@ fn test_extremes() {
         Duration::from_truncated_nanoseconds(d.truncated_nanoseconds()),
         d
     );
+
+    let past_min = Duration::from_total_nanoseconds(i128::MIN);
+    assert_eq!(past_min, Duration::MIN);
 }
 
 #[test]

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -159,7 +159,7 @@ fn duration_format() {
     assert_eq!(delta * -1.0, 0.0);
     assert_eq!(format!("{}", sum), "-35 min");
 
-    assert_eq!(format!("{}", Duration::MAX), "1196851200 days");
+    assert_eq!(format!("{}", Duration::MAX), "1196887725 days");
     assert_eq!(format!("{}", Duration::MIN), "-1196887725 days");
     assert_eq!(format!("{}", Duration::ZERO), "0 ns");
 
@@ -214,10 +214,28 @@ fn test_ops() {
 }
 
 #[test]
+fn test_ops_near_bounds() {
+    assert_eq!(Duration::MAX - Duration::MAX, 0 * Unit::Nanosecond);
+    assert_eq!(Duration::MIN - Duration::MIN, 0 * Unit::Nanosecond);
+
+    // Check that the special cases of the bounds themselves don't prevent correct math.
+    assert_eq!(
+        (Duration::MIN + 1 * Unit::Nanosecond) - (Duration::MIN + 1 * Unit::Nanosecond),
+        0 * Unit::Century
+    );
+}
+
+#[test]
 fn test_neg() {
     assert_eq!(Duration::MIN_NEGATIVE, -Duration::MIN_POSITIVE);
     assert_eq!(Duration::MIN_POSITIVE, -Duration::MIN_NEGATIVE);
     assert_eq!(2.nanoseconds(), -(2.0.nanoseconds()));
+    assert_eq!(Duration::MIN, -Duration::MAX);
+    assert_eq!(Duration::MAX, -Duration::MIN);
+    assert_eq!(
+        Duration::MIN + 1 * Unit::Nanosecond,
+        -(Duration::MAX - 1 * Unit::Nanosecond)
+    );
 }
 
 #[test]

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -221,8 +221,8 @@ fn test_ops_near_bounds() {
 
     // Check that the special cases of the bounds themselves don't prevent correct math.
     assert_eq!(
-        (Duration::MIN + 1 * Unit::Nanosecond) - (Duration::MIN + 1 * Unit::Nanosecond),
-        0 * Unit::Century
+        (Duration::MIN - 1 * Unit::Nanosecond) - (Duration::MIN - 1 * Unit::Nanosecond),
+        0 * Unit::Nanosecond
     );
 
     let tt_offset_ns: u64 = 32_184_000_000;
@@ -232,6 +232,10 @@ fn test_ops_near_bounds() {
         duration - Duration::from_total_nanoseconds(tt_offset_ns.into()),
         exp
     );
+
+    // Check that we saturate one way but not the other
+    assert_ne!(Duration::MIN + 1 * Unit::Nanosecond, Duration::MIN);
+    assert_ne!(Duration::MAX - 1 * Unit::Nanosecond, Duration::MAX);
 }
 
 #[test]

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -821,6 +821,9 @@ fn test_from_str() {
         Epoch::from_gregorian_utc(2017, 1, 14, 0, 31, 55, 811000000),
         Epoch::from_gregorian(2017, 1, 14, 0, 31, 55, 811000000, TimeScale::UTC),
     );
+
+    // Check that we can correctly parse the result from a hardware clock.
+    assert!(Epoch::from_str("2022-12-15 13:32:16.421857-07:00").is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Refer to #184 for progress.

Implements #184 

List of bugs fixed thanks to Kani:

+ `normalize()` in Duration (which is called after _every_ operation on a Duration) could overflow near the maximum or minimum number of centuries when the nanoseconds were still within the MIN/MAX of the structure.
+ `normalize()` in Duration would overflow when the duration was _near_ (but below) the MAX
+ `Duration::neg()` would overflow near MIN/MAX
+ `PartialEq` on `Duration` would overflow near MIN/MAX
+ `try_truncated_nanoseconds` would overflow on any duration where the input was larger than the MAX
+ `Ops::Add` would fail when the centuries was the `i16::MIN` but the nanoseconds were still valid
+ `Ops::Add` would overflow when the right hand side input was not normalized
+ `Ops::Sub` would underflow when subtracting a duration whose nanoseconds was greater than `self` and when `self.centuries` was near the MIN.
