### PR TITLE
Update artifact-related actions in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
           args: --release --sdist -o dist --find-interpreter -F python
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -35,7 +35,7 @@ jobs:
           command: build
           args: --release -o dist --find-interpreter -F python
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -49,7 +49,7 @@ jobs:
           command: build
           args: --release -o dist --universal2 --find-interpreter -F python
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -60,7 +60,7 @@ jobs:
     if: github.ref_type == 'tag'
     needs: [macos, windows, linux]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
       - name: Publish to PyPI


### PR DESCRIPTION
This updates `actions/download-artifact` and `actions/upload-artifact` to their newest major version v3.

Changes in [actions/download-artifact](https://github.com/actions/download-artifact):
> ## v3.0.2
> - Bump `@actions/artifact` to v1.1.1
> - Fixed a bug in Node16 where if an HTTP download finished too quickly (<1ms, e.g. when it's mocked) we attempt to delete a temp file that has not been created yet
>
> ## v3.0.1
> - Bump @actions/core to 1.10.0
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):
> ## v3.1.2
> Update all `@actions/*` NPM packages to their latest versions
> Update all dev dependencies to their most recent versions
>
> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/download-artifact` and `actions/upload-artifact` will generate warnings like in this run: https://github.com/nyx-space/hifitime/actions/runs/3807815631

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/download-artifact@v2

and

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/upload-artifact@v2

The PR will get rid of those warnings for `actions/download-artifact` and `actions/upload-artifact`, because v3 uses Node.js 16 in both cases.