### PR TITLE
Use `-Z sparse-registry` when running Kani

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -36,7 +36,7 @@ jobs:
           # Remove `cdylib` from targets in Cargo.toml because it confuses Kani
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
-          cargo kani
+          cargo -Z sparse-registry kani
 
       - name: Save formal verification artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This commit adds `-Z sparse-registry` to the cargo kani invocation, which is needed to update crates over HTTP.

This commit fixes model-checking/kani-github-action#30