### PR TITLE
support qzss time scale

### DIFF
--- a/src/asn1der.rs
+++ b/src/asn1der.rs
@@ -62,7 +62,8 @@ impl<'a> Decode<'a> for Epoch {
             TimeScale::ET => Self::from_et_duration(duration),
             TimeScale::TDB => Self::from_tdb_duration(duration),
             TimeScale::UTC => Self::from_utc_duration(duration),
-            TimeScale::GPST => Self::from_gpst_duration(duration),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => Self::from_gpst_duration(duration),
             TimeScale::GST => Self::from_gst_duration(duration),
             TimeScale::BDT => Self::from_bdt_duration(duration),
         })
@@ -107,9 +108,10 @@ fn test_encdec() {
             TimeScale::TT => epoch.to_tt_duration(),
             TimeScale::TDB => epoch.to_tdb_duration(),
             TimeScale::UTC => epoch.to_utc_duration(),
-            TimeScale::GPST => epoch.to_gpst_duration(),
             TimeScale::GST => epoch.to_gst_duration(),
             TimeScale::BDT => epoch.to_bdt_duration(),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => epoch.to_gpst_duration(),
         };
 
         let e_dur = epoch.to_duration();

--- a/src/asn1der.rs
+++ b/src/asn1der.rs
@@ -62,8 +62,8 @@ impl<'a> Decode<'a> for Epoch {
             TimeScale::ET => Self::from_et_duration(duration),
             TimeScale::TDB => Self::from_tdb_duration(duration),
             TimeScale::UTC => Self::from_utc_duration(duration),
-            // GPST and QZSST share the same properties
-            TimeScale::GPST | TimeScale::QZSST => Self::from_gpst_duration(duration),
+            TimeScale::GPST => Self::from_gpst_duration(duration),
+            TimeScale::QZSST => Self::from_qzsst_duration(duration),
             TimeScale::GST => Self::from_gst_duration(duration),
             TimeScale::BDT => Self::from_bdt_duration(duration),
         })
@@ -93,7 +93,7 @@ impl<'a> Decode<'a> for Unit {
 // Testing the encoding and decoding of an Epoch inherently also tests the encoding and decoding of a Duration
 #[test]
 fn test_encdec() {
-    for ts_u8 in 0..=7 {
+    for ts_u8 in 0..=8 {
         let ts: TimeScale = ts_u8.into();
 
         let epoch = if ts == TimeScale::UTC {
@@ -108,10 +108,10 @@ fn test_encdec() {
             TimeScale::TT => epoch.to_tt_duration(),
             TimeScale::TDB => epoch.to_tdb_duration(),
             TimeScale::UTC => epoch.to_utc_duration(),
+            TimeScale::GPST => epoch.to_gpst_duration(),
             TimeScale::GST => epoch.to_gst_duration(),
             TimeScale::BDT => epoch.to_bdt_duration(),
-            // GPST and QZSST share the same properties
-            TimeScale::GPST | TimeScale::QZSST => epoch.to_gpst_duration(),
+            TimeScale::QZSST => epoch.to_qzsst_duration(),
         };
 
         let e_dur = epoch.to_duration();
@@ -132,7 +132,7 @@ fn test_encdec() {
         // Check that the time scale used is preserved
         assert_eq!(
             encdec_epoch.time_scale, ts,
-            "Decoded time system incorrect {ts:?}"
+            "Decoded time system incorrect {ts:?}",
         );
     }
 

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -272,8 +272,8 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
             TimeScale::UTC => Self::from_utc_duration(new_duration),
-            // GPST and QZSST share the same properties
-            TimeScale::GPST | TimeScale::QZSST => Self::from_gpst_duration(new_duration),
+            TimeScale::GPST => Self::from_gpst_duration(new_duration),
+            TimeScale::QZSST => Self::from_qzsst_duration(new_duration),
             TimeScale::GST => Self::from_gst_duration(new_duration),
             TimeScale::BDT => Self::from_bdt_duration(new_duration),
         }
@@ -348,6 +348,15 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
+    pub fn from_qzsst_duration(duration: Duration) -> Self {
+        // QZSST and GPST share the same reference epoch
+        let mut me = Self::from_tai_duration(GPST_REF_EPOCH.to_tai_duration() + duration);
+        me.time_scale = TimeScale::QZSST;
+        me
+    }
+
+    #[must_use]
     /// Initialize an Epoch from the provided duration since August 21st 1999 midnight
     pub fn from_gst_duration(duration: Duration) -> Self {
         let mut me = Self::from_tai_duration(GST_REF_EPOCH.to_tai_duration() + duration);
@@ -391,6 +400,10 @@ impl Epoch {
         Self::from_mjd_in_time_scale(days, TimeScale::GPST)
     }
     #[must_use]
+    pub fn from_mjd_qzsst(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::QZSST)
+    }
+    #[must_use]
     pub fn from_mjd_gst(days: f64) -> Self {
         Self::from_mjd_in_time_scale(days, TimeScale::GST)
     }
@@ -425,6 +438,10 @@ impl Epoch {
     #[must_use]
     pub fn from_jde_gpst(days: f64) -> Self {
         Self::from_jde_in_time_scale(days, TimeScale::GPST)
+    }
+    #[must_use]
+    pub fn from_jde_qzsst(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::QZSST)
     }
     #[must_use]
     pub fn from_jde_gst(days: f64) -> Self {
@@ -570,6 +587,34 @@ impl Epoch {
                 nanoseconds,
             },
             TimeScale::GPST,
+        )
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of seconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_qzsst_seconds(seconds: f64) -> Self {
+        Self::from_duration(Duration::from_f64(seconds, Unit::Second), TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of days since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_qzsst_days(days: f64) -> Self {
+        Self::from_duration(Duration::from_f64(days, Unit::Day), TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of nanoseconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// This may be useful for time keeping devices that use QZSS as a time source.
+    pub fn from_qzsst_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_duration(
+            Duration {
+                centuries: 0,
+                nanoseconds,
+            },
+            TimeScale::QZSST,
         )
     }
 
@@ -729,9 +774,12 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::TDB => Self::from_tdb_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::UTC => Self::from_utc_duration(duration_wrt_1900),
-            // GPST and QZSST share the same properties
-            TimeScale::GPST | TimeScale::QZSST => {
+            TimeScale::GPST => {
                 Self::from_gpst_duration(duration_wrt_1900 - GPST_REF_EPOCH.to_tai_duration())
+            }
+            // QZSS and GPST share the same reference epoch
+            TimeScale::QZSST => {
+                Self::from_qzsst_duration(duration_wrt_1900 - GPST_REF_EPOCH.to_tai_duration())
             }
             TimeScale::GST => {
                 Self::from_gst_duration(duration_wrt_1900 - GST_REF_EPOCH.to_tai_duration())
@@ -1428,6 +1476,31 @@ impl Epoch {
 
     #[cfg(feature = "python")]
     #[classmethod]
+    /// Initialize an Epoch from the number of seconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    fn init_from_qzsst_seconds(_cls: &PyType, seconds: f64) -> Self {
+        Self::from_qzsst_seconds(seconds)
+    }
+
+    #[cfg(feature = "python")]
+    #[classmethod]
+    /// Initialize an Epoch from the number of days since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    fn init_from_qzsst_days(_cls: &PyType, days: f64) -> Self {
+        Self::from_qzsst_days(days)
+    }
+
+    #[cfg(feature = "python")]
+    #[classmethod]
+    /// Initialize an Epoch from the number of nanoseconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// This may be useful for time keeping devices that use QZSS as a time source.
+    fn init_from_qzsst_nanoseconds(_cls: &PyType, nanoseconds: u64) -> Self {
+        Self::from_qzsst_nanoseconds(nanoseconds)
+    }
+
+    #[cfg(feature = "python")]
+    #[classmethod]
     /// Initialize an Epoch from the number of seconds since the Galileo Time Epoch,
     /// starting on August 21st 1999 Midnight UT,
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
@@ -1988,6 +2061,31 @@ impl Epoch {
     }
 
     #[must_use]
+    /// Returns seconds past QZSS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn to_qzsst_seconds(&self) -> f64 {
+        self.to_qzsst_duration().to_seconds()
+    }
+
+    #[must_use]
+    /// Returns `Duration` past QZSS time Epoch.
+    pub fn to_qzsst_duration(&self) -> Duration {
+        // GPST and QZSST share the same reference epoch
+        self.duration_since_j1900_tai - GPST_REF_EPOCH.to_tai_duration()
+    }
+
+    /// Returns nanoseconds past QZSS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// NOTE: This function will return an error if the centuries past QZSST time are not zero.
+    pub fn to_qzsst_nanoseconds(&self) -> Result<u64, Errors> {
+        self.to_nanoseconds_in_time_scale(TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Returns days past QZSS Time Epoch, defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn to_qzsst_days(&self) -> f64 {
+        self.to_gpst_duration().to_unit(Unit::Day)
+    }
+
+    #[must_use]
     /// Returns seconds past GST (Galileo) Time Epoch
     pub fn to_gst_seconds(&self) -> f64 {
         self.to_gst_duration().to_seconds()
@@ -1999,19 +2097,19 @@ impl Epoch {
         self.duration_since_j1900_tai - GST_REF_EPOCH.to_tai_duration()
     }
 
+    /// Returns nanoseconds past GST (Galileo) Time Epoch, starting on August 21st 1999 Midnight UT
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    /// NOTE: This function will return an error if the centuries past GST time are not zero.
+    pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {
+        self.to_nanoseconds_in_time_scale(TimeScale::GST)
+    }
+
     #[must_use]
     /// Returns days past GST (Galileo) Time Epoch,
     /// starting on August 21st 1999 Midnight UT
     /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
     pub fn to_gst_days(&self) -> f64 {
         self.to_gst_duration().to_unit(Unit::Day)
-    }
-
-    /// Returns nanoseconds past GST (Galileo) Time Epoch, starting on August 21st 1999 Midnight UT
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
-    /// NOTE: This function will return an error if the centuries past GST time are not zero.
-    pub fn to_gst_nanoseconds(&self) -> Result<u64, Errors> {
-        self.to_nanoseconds_in_time_scale(TimeScale::GST)
     }
 
     #[must_use]

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -272,7 +272,8 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
             TimeScale::UTC => Self::from_utc_duration(new_duration),
-            TimeScale::GPST => Self::from_gpst_duration(new_duration),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => Self::from_gpst_duration(new_duration),
             TimeScale::GST => Self::from_gst_duration(new_duration),
             TimeScale::BDT => Self::from_bdt_duration(new_duration),
         }
@@ -728,7 +729,8 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::TDB => Self::from_tdb_duration(duration_wrt_1900 - J2000_TO_J1900_DURATION),
             TimeScale::UTC => Self::from_utc_duration(duration_wrt_1900),
-            TimeScale::GPST => {
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => {
                 Self::from_gpst_duration(duration_wrt_1900 - GPST_REF_EPOCH.to_tai_duration())
             }
             TimeScale::GST => {
@@ -1712,9 +1714,10 @@ impl Epoch {
             TimeScale::ET => self.to_et_duration(),
             TimeScale::TDB => self.to_tdb_duration(),
             TimeScale::UTC => self.to_utc_duration(),
-            TimeScale::GPST => self.to_gpst_duration(),
             TimeScale::BDT => self.to_bdt_duration(),
             TimeScale::GST => self.to_gst_duration(),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => self.to_gpst_duration(),
         }
     }
 
@@ -1747,7 +1750,10 @@ impl Epoch {
             TimeScale::TT => self.to_tt_duration(),
             TimeScale::TDB => self.to_tdb_duration_since_j1900(),
             TimeScale::UTC => self.to_utc_duration(),
-            TimeScale::GPST => self.to_gpst_duration() + GPST_REF_EPOCH.to_tai_duration(),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => {
+                self.to_gpst_duration() + GPST_REF_EPOCH.to_tai_duration()
+            }
             TimeScale::GST => self.to_gst_duration() + GST_REF_EPOCH.to_tai_duration(),
             TimeScale::BDT => self.to_bdt_duration() + BDT_REF_EPOCH.to_tai_duration(),
         }
@@ -1762,7 +1768,8 @@ impl Epoch {
             TimeScale::ET => Self::from_et_duration(new_duration),
             TimeScale::TDB => Self::from_tdb_duration(new_duration),
             TimeScale::UTC => Self::from_utc_duration(new_duration),
-            TimeScale::GPST => Self::from_gpst_duration(new_duration),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => Self::from_gpst_duration(new_duration),
             TimeScale::GST => Self::from_gst_duration(new_duration),
             TimeScale::BDT => Self::from_bdt_duration(new_duration),
         }
@@ -2737,7 +2744,8 @@ impl Epoch {
             TimeScale::ET => self.to_et_duration_since_j1900(),
             TimeScale::TDB => self.to_tdb_duration_since_j1900(),
             TimeScale::UTC => self.to_utc_duration(),
-            TimeScale::GPST => self.to_utc_duration(),
+            // GPST and QZSST share the same properties
+            TimeScale::GPST | TimeScale::QZSST => self.to_utc_duration(),
             TimeScale::GST => self.to_utc_duration(),
             TimeScale::BDT => self.to_utc_duration(),
         });

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -200,7 +200,7 @@ impl From<TimeScale> for u8 {
 }
 
 /// Allows conversion of a u8 into a TimeSystem.
-/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; 5: GPST; 6: GST; 7: BDT; anything else: TAI
+/// Mapping: 1: TT; 2: ET; 3: TDB; 4: UTC; 5: GPST; 6: GST; 7: BDT; 8: QZSST; anything else: TAI
 impl From<u8> for TimeScale {
     fn from(val: u8) -> Self {
         match val {

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -64,6 +64,7 @@ pub const UNIX_REF_EPOCH: Epoch = Epoch::from_tai_duration(Duration {
 });
 
 /// Enum of the different time systems available
+#[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -182,7 +182,7 @@ impl TimeScale {
 }
 
 /// Allows conversion of a TimeSystem into a u8
-/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4; GPST: 5; GST: 6; BDT: 7;
+/// Mapping: TAI: 0; TT: 1; ET: 2; TDB: 3; UTC: 4; GPST: 5; GST: 6; BDT: 7; QZSST: 8;
 impl From<TimeScale> for u8 {
     fn from(ts: TimeScale) -> Self {
         match ts {

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -955,6 +955,7 @@ fn test_format() {
                     TimeScale::GPST => format!("{epoch:x}").replace("TAI", "GPST"),
                     TimeScale::GST => format!("{epoch:x}").replace("TAI", "GST"),
                     TimeScale::BDT => format!("{epoch:x}").replace("TAI", "BDT"),
+                    TimeScale::QZSST => format!("{epoch:x}").replace("TAI", "QZSST"),
                 }
             );
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -335,12 +335,31 @@ fn gpst() {
     let ref_gps = Epoch::from_gregorian_utc_at_midnight(1980, 01, 06);
 
     // Test 1sec into GPS timescale
-    let gnss = Epoch::from_gpst_seconds(1.0);
-    assert_eq!(gnss, ref_gps + 1.0 * Unit::Second);
+    let gps_1sec = Epoch::from_gpst_seconds(1.0);
+    assert_eq!(gps_1sec, ref_gps + 1.0 * Unit::Second);
+
+    // 1sec into QZSS time scale returns the same date
+    let qzss_1sec = Epoch::from_qzsst_seconds(1.0);
+    assert_eq!(gps_1sec.to_utc_duration(), qzss_1sec.to_utc_duration());
+
+    // GPS and QZSS share the same properties at all times
+    assert_eq!(gps_1sec.to_gpst_seconds(), qzss_1sec.to_qzsst_seconds());
+    assert_eq!(
+        gps_1sec.to_gpst_nanoseconds(),
+        qzss_1sec.to_qzsst_nanoseconds()
+    );
 
     // Test 1+1/2 day into GPS timescale
-    let gnss = Epoch::from_gpst_days(1.5);
-    assert_eq!(gnss, ref_gps + 1.5 * Unit::Day);
+    let gps = Epoch::from_gpst_days(1.5);
+    assert_eq!(gps, ref_gps + 1.5 * Unit::Day);
+
+    // 1sec into QZSS time scale returns the same date
+    let qzss = Epoch::from_qzsst_days(1.5);
+    assert_eq!(gps.to_utc_duration(), qzss.to_utc_duration());
+
+    // GPS and QZSS share the same properties at all times
+    assert_eq!(gps.to_gpst_seconds(), qzss.to_qzsst_seconds());
+    assert_eq!(gps.to_gpst_nanoseconds(), qzss.to_qzsst_nanoseconds());
 
     let now = Epoch::from_gregorian_tai_hms(2019, 8, 24, 3, 49, 9);
     assert_eq!(
@@ -390,6 +409,28 @@ fn gpst() {
     let epoch = Epoch::from_gregorian_utc_at_midnight(1980, 1, 1);
     assert!((epoch.to_gpst_seconds() + 5.0 * SECONDS_PER_DAY).abs() < EPSILON);
     assert!((epoch.to_gpst_days() + 5.0).abs() < EPSILON);
+
+    // test other GPS / QZSS equalities
+    assert_eq!(
+        Epoch::from_mjd_gpst(0.77).to_utc_duration(),
+        Epoch::from_mjd_qzsst(0.77).to_utc_duration()
+    );
+    assert_eq!(
+        Epoch::from_jde_gpst(1.23).to_utc_duration(),
+        Epoch::from_jde_qzsst(1.23).to_utc_duration()
+    );
+    assert_eq!(
+        Epoch::from_qzsst_seconds(1024.768).to_utc_duration(),
+        Epoch::from_gpst_seconds(1024.768).to_utc_duration()
+    );
+    assert_eq!(
+        Epoch::from_qzsst_days(987.654).to_utc_duration(),
+        Epoch::from_gpst_days(987.654).to_utc_duration()
+    );
+    assert_eq!(
+        Epoch::from_qzsst_nanoseconds(543210987).to_utc_duration(),
+        Epoch::from_gpst_nanoseconds(543210987).to_utc_duration()
+    );
 }
 
 #[test]
@@ -1550,6 +1591,13 @@ fn test_time_of_week() {
         Epoch::from_time_of_week(utc_wk, utc_tow, TimeScale::UTC),
         epoch_utc
     );
+
+    // GPST and QZSST share the same properties at all times
+    let epoch_qzsst = epoch.in_time_scale(TimeScale::QZSST);
+    assert_eq!(epoch.to_gregorian_utc(), epoch_qzsst.to_gregorian_utc());
+
+    let gps_qzss_offset = TimeScale::GPST.ref_epoch() - TimeScale::QZSST.ref_epoch();
+    assert_eq!(gps_qzss_offset.total_nanoseconds(), 0); // no offset
 
     // 06/01/1980 01:00:00 = 1H into GPST <=> (0, 3_618_000_000_000)
     let epoch = Epoch::from_time_of_week(0, 3_618_000_000_000, TimeScale::GPST);

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -956,6 +956,7 @@ fn test_format() {
                     TimeScale::GST => format!("{epoch:x}").replace("TAI", "GST"),
                     TimeScale::BDT => format!("{epoch:x}").replace("TAI", "BDT"),
                     TimeScale::QZSST => format!("{epoch:x}").replace("TAI", "QZSST"),
+                    _ => format!("{epoch:x}").replace("TAI", "GNSS"), // non exhaustive GNSS time scales
                 }
             );
 

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -12,6 +12,7 @@ fn test_from_str() {
         ("GPST", TimeScale::GPST),
         ("GST", TimeScale::GST),
         ("BDT", TimeScale::BDT),
+        ("QZSST", TimeScale::QZSST),
     ];
     for value in values {
         let (descriptor, expected) = value;
@@ -26,6 +27,7 @@ fn test_from_str() {
             TimeScale::GPST => "GPS",
             TimeScale::GST => "GAL",
             TimeScale::BDT => "BDS",
+            TimeScale::QZSST => "QZSS",
             _ => descriptor, // untouched
         };
         assert_eq!(format!("{:x}", ts), expected);
@@ -41,6 +43,7 @@ fn test_from_rinex_format() {
     assert_eq!(TimeScale::from_str("GPS"), Ok(TimeScale::GPST));
     assert_eq!(TimeScale::from_str("GAL"), Ok(TimeScale::GST));
     assert_eq!(TimeScale::from_str("BDS"), Ok(TimeScale::BDT));
+    assert_eq!(TimeScale::from_str("QZSS"), Ok(TimeScale::QZSST));
     // Check error
     assert_eq!(
         TimeScale::from_str("FAK"),
@@ -58,6 +61,8 @@ fn test_is_gnss() {
     assert!(!ts.is_gnss());
     let ts = TimeScale::TAI;
     assert!(!ts.is_gnss());
+    let ts = TimeScale::QZSST;
+    assert!(ts.is_gnss());
 }
 
 #[test]


### PR DESCRIPTION
Introduces QZSS time scale, which is straight forward in the sense it behaves like GPST strictly, but comes from a set of dedicated clocks.

Partial answer to issue #210