### PR TITLE
Adds support for using hifitime in WASM targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,21 @@ reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
 tabled = { version = "0.14.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
+[target.wasm32-unknown-unknown.dependencies]
+js-sys = { version = "0.3"}
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2"}
+web-sys = { version = "0.3", features = ['Window', 'Performance', 'PerformanceTiming'] }
+
+[target.wasm32-unknown-emscripten.dependencies]
+js-sys = { version = "0.3"}
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2"}
+web-sys = { version = "0.3", features = ['Window', 'Performance', 'PerformanceTiming'] }
+
+[target.asmjs-unknown-emscripten.dependencies]
+js-sys = { version = "0.3"}
+wasm-bindgen_rs = { package = "wasm-bindgen", version = "0.2"}
+web-sys = { version = "0.3", features = ['Window', 'Performance', 'PerformanceTiming'] }
+
 [dev-dependencies]
 serde_json = "1.0.91"
 criterion = "0.5.1"

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -44,8 +44,6 @@ use crate::leap_seconds_file::LeapSecondsFile;
 use serde_derive::{Deserialize, Serialize};
 
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::time::SystemTime;
 
 #[cfg(not(feature = "std"))]
 use num_traits::{Euclid, Float};
@@ -628,6 +626,12 @@ impl Epoch {
             },
             TimeScale::BDT,
         )
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since UTC midnight 1970 January 01.
+    pub fn from_unix_duration(duration: Duration) -> Self {
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + duration)
     }
 
     #[must_use]
@@ -2827,12 +2831,11 @@ impl Epoch {
 impl Epoch {
     /// Initializes a new Epoch from `now`.
     /// WARNING: This assumes that the system time returns the time in UTC (which is the case on Linux)
-    /// Uses [`std::time::SystemTime::now`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now) under the hood
+    /// Uses [`std::time::SystemTime::now`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now)
+    /// or javascript interop under the hood
     pub fn now() -> Result<Self, Errors> {
-        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-            Ok(std_duration) => Ok(Self::from_unix_seconds(std_duration.as_secs_f64())),
-            Err(_) => Err(Errors::SystemTimeError),
-        }
+        let duration = crate::system_time::duration_since_unix_epoch()?;
+        Ok(Self::from_unix_duration(duration))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,3 +141,6 @@ pub mod python;
 
 #[cfg(feature = "std")]
 extern crate core;
+
+#[cfg(feature = "std")]
+mod system_time;

--- a/src/system_time.rs
+++ b/src/system_time.rs
@@ -1,0 +1,22 @@
+use crate::{Duration, Errors};
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn duration_since_unix_epoch() -> Result<Duration, Errors> {
+    {
+        use crate::Unit;
+        use wasm_bindgen_rs::prelude::*;
+        js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("performance"))
+            .map_err(|_| Errors::SystemTimeError)
+            .map(|performance| {
+                performance.unchecked_into::<web_sys::Performance>().now() * Unit::Second
+            })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn duration_since_unix_epoch() -> Result<Duration, Errors> {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map_err(|_| Errors::SystemTimeError)
+        .and_then(|d| d.try_into().map_err(|_| Errors::SystemTimeError))
+}


### PR DESCRIPTION
`std::time::SystemClock::now()` does not work in the browser. The [instant](https://crates.io/crates/instant) provides an alternative that works in the browser and falls back to `std::time::SystemClock` on non-WASM targets. I have added a new `web` feature flag that enables the extra features from the `instant` crate.

This is required for running the [ANISE](https://github.com/nyx-space/anise) gui in the browser. 