### PR TITLE
docs(fix): fixed reversed description of duration magnitude

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -54,7 +54,7 @@ pub const NANOSECONDS_PER_CENTURY: u64 = DAYS_PER_CENTURY_U64 * NANOSECONDS_PER_
 /// **Important conventions:**
 /// 1. The negative durations can be mentally modeled "BC" years. One hours before 01 Jan 0000, it was "-1" years but  365 days and 23h into the current day.
 /// It was decided that the nanoseconds corresponds to the nanoseconds _into_ the current century. In other words,
-/// a duration with centuries = -1 and nanoseconds = 0 is _a smaller duration_ (further from zero) than centuries = -1 and nanoseconds = 1.
+/// a duration with centuries = -1 and nanoseconds = 0 is _a greater duration_ (further from zero) than centuries = -1 and nanoseconds = 1.
 /// Duration zero minus one nanosecond returns a century of -1 and a nanosecond set to the number of nanoseconds in one century minus one.
 /// That difference is exactly 1 nanoseconds, where the former duration is "closer to zero" than the latter.
 /// As such, the largest negative duration that can be represented sets the centuries to i16::MAX and its nanoseconds to NANOSECONDS_PER_CENTURY.


### PR DESCRIPTION
Just a fix of what I believe is a typo, but also a couple out-of-code comments re: possible changes.

Fix: the docs said that -1 century < (-1 century + 1 ns), which I believe is the opposite of what you meant.  (Had to download library and check though since, per the point of explaining, it could've gone either way :)

A couple other things that might be worth changing/clarifying:

1. > It was decided that the nanoseconds corresponds to the nanoseconds _into_ the current century.
    - I think that's *also* untrue, yes?  Nanoseconds are toward "the future" as it were.  Rather than toward any period (absolute or dynamic).  Technical correctness aside, I also found that phrasing confusing.  (But I'm not a space-related scientist, so maybe this is common phrasing in your field. ?)

2. > The negative durations can be mentally modeled "BC" years. One hours before 01 Jan 0000, it was "-1" years but  365 days and 23h into the current day.
    - This is helpful, but might it be simpler to just refer to the sign of both durations *and* components as pointing to the past (back) or future (forward)?  This also sets up the clean reading of +/- centuries, + nanoseconds as just being negative + positive.
    
Just figured I'd bring it up in case you thought minor re-wording could help, since I was making a (micro) PR.
(I've only just found your crate, so I have zero expertise here and may be misunderstanding its intended interpretation.)