### PR TITLE
Draft: replace std::time:SystemTime with web_time::SystemTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lexical-core = { version = "0.8.5", default-features = false, features = [
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
 tabled = { version = "0.15.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
+web-time = { version = "1.0.0" }
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = { version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ lexical-core = { version = "0.8.5", default-features = false, features = [
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
 tabled = { version = "0.15.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
-web-time = { version = "1.0.0" }
+web-time = { version = "1.0.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = { version = "0.3" }
@@ -68,7 +68,7 @@ iai = "0.1"
 
 [features]
 default = ["std"]
-std = ["serde", "serde_derive"]
+std = ["serde", "serde_derive", "web-time"]
 asn1der = ["der"]
 python = ["std", "asn1der", "pyo3", "ut1"]
 ut1 = ["std", "reqwest", "tabled", "openssl"]

--- a/src/system_time.rs
+++ b/src/system_time.rs
@@ -1,22 +1,8 @@
 use crate::{Duration, Errors};
 
-#[cfg(target_arch = "wasm32")]
 pub(crate) fn duration_since_unix_epoch() -> Result<Duration, Errors> {
-    {
-        use crate::Unit;
-        use wasm_bindgen_rs::prelude::*;
-        js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("performance"))
-            .map_err(|_| Errors::SystemTimeError)
-            .map(|performance| {
-                performance.unchecked_into::<web_sys::Performance>().now() * Unit::Second
-            })
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn duration_since_unix_epoch() -> Result<Duration, Errors> {
-    std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+    web_time::SystemTime::now()
+        .duration_since(web_time::SystemTime::UNIX_EPOCH)
         .map_err(|_| Errors::SystemTimeError)
         .and_then(|d| d.try_into().map_err(|_| Errors::SystemTimeError))
 }

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -526,7 +526,7 @@ fn unix() {
     // Continuous check that the system time as reported by this machine is within millisecond accuracy of what we compute
     #[cfg(feature = "std")]
     {
-        use std::time::SystemTime;
+        use web_time::SystemTime;
 
         let std_unix_time_s = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
Would fix #278 
Allows consistent usage of SystemTime between targets (including WASM).

I replaced all uses of std::time::SystemTime with web_time::SystemTime, and removed the overloaded `duration_since_unix_epoch` method for the WASM target.

I haven't vetted the web_time library for other uses, but it seems to be working fine. 
So this is just a proposal and might need more discussion/research before including as dependency.