### PR TITLE
Fix panic caused by arithmetic overflow

### DIFF
--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -737,7 +737,7 @@ impl Epoch {
             Some(years_since_1900) => match years_since_1900.checked_mul(365) {
                 None => return Err(Errors::Overflow),
                 Some(days) => (years_since_1900, Unit::Day * i64::from(days)),
-            }
+            },
         };
 
         // count leap years

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -732,8 +732,8 @@ impl Epoch {
             return Err(Errors::Carry);
         }
 
-        let years_since_1900 = year - 1900;
-        let mut duration_wrt_1900 = Unit::Day * i64::from(365 * years_since_1900);
+        let years_since_1900 = year.saturating_sub(1900);
+        let mut duration_wrt_1900 = Unit::Day * i64::from(years_since_1900.saturating_mul(365));
 
         // count leap years
         if years_since_1900 > 0 {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -732,8 +732,13 @@ impl Epoch {
             return Err(Errors::Carry);
         }
 
-        let years_since_1900 = year.saturating_sub(1900);
-        let mut duration_wrt_1900 = Unit::Day * i64::from(years_since_1900.saturating_mul(365));
+        let (years_since_1900, mut duration_wrt_1900) = match year.checked_sub(1900) {
+            None => return Err(Errors::Overflow),
+            Some(years_since_1900) => match years_since_1900.checked_mul(365) {
+                None => return Err(Errors::Overflow),
+                Some(days) => (years_since_1900, Unit::Day * i64::from(days)),
+            }
+        };
 
         // count leap years
         if years_since_1900 > 0 {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,10 +76,7 @@ impl fmt::Display for Errors {
             Self::ConversionOverlapError(hi, lo) => {
                 write!(f, "hi and lo values overlap: {}, {}", hi, lo)
             }
-            Self::Overflow => write!(
-                f,
-                "overflow occurred when trying to convert Duration information"
-            ),
+            Self::Overflow => write!(f, "prevented overflow/underflow"),
             Self::SystemTimeError => write!(f, "std::time::SystemTime returned an error"),
         }
     }


### PR DESCRIPTION
Fix 11. and 12. Arithmetic overflow bug and  in #244 
Consider using saturating_sub and saturating_mul to avoid the panic.

The problem lies in https://github.com/nyx-space/hifitime/blob/822c0a0ee4da21f385bc520547431fd1b3ed7d6f/src/epoch.rs#L735
where `year_since_1900` is overflowing to i32.

https://github.com/nyx-space/hifitime/blob/822c0a0ee4da21f385bc520547431fd1b3ed7d6f/src/epoch.rs#L736
where `365 * yeaer_since_1900` is overflowing to i32.

I've opted to use `saturating_sub` and `saturating_mul`. These functions ensure that there's a maximum boundary, preventing overflow panic.

PS: As a newcomer to the Rust project, I apologize for any inconvenience this may cause.