### PR TITLE
Fix panic caused by array out of bounds

### DIFF
--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1045,6 +1045,10 @@ impl Epoch {
                     idx + 1
                 };
 
+                if prev_idx > end_idx {
+                    return Err(Errors::ParseError(ParsingErrors::ISO8601));
+                }
+
                 match lexical_core::parse(s[prev_idx..end_idx].as_bytes()) {
                     Ok(val) => {
                         // Check that this valid is OK for the token we're reading it as.


### PR DESCRIPTION
Fix 1. Array out-of-bounds error in #244 

In the replay file, the input "94-11-05T08:15:34.0-:0" does not adhere to the Gregorian date time format, leading to prev_idx > end_idx, which, in my opinion, should trigger an error.