### PR TITLE
Fix panic caused by unwrap

### DIFF
--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -156,7 +156,10 @@ impl Format {
         // Previous index of interest in the string
         let mut prev_idx = 0;
         let mut cur_item_idx = 0;
-        let mut cur_item = self.items[cur_item_idx].unwrap();
+        let mut cur_item =  match self.items[cur_item_idx] {
+            Some(item) => item,
+            None => return Err(Errors::ParseError(ParsingErrors::UnknownFormat)),
+        };
         let mut cur_token = cur_item.token;
         let mut prev_item = cur_item;
         let mut prev_token;


### PR DESCRIPTION
Fix 8.Unwrap error in #244 

In the replay file, `from_format_str` takes "%" as format_str, thus causing the format returned by `from_str` empty.

https://github.com/nyx-space/hifitime/blob/822c0a0ee4da21f385bc520547431fd1b3ed7d6f/src/efmt/format.rs#L159

This results in the items in `parse` being empty, which causes an unwrap error. In my opinion, it should be classified as an UnknownFormat error since it's related to format.