### PR TITLE
Improve error handling

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -117,16 +117,20 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        platform:
+          - runner: macos-latest
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter -F python
           sccache: 'true'
       - name: Upload wheels
@@ -135,10 +139,11 @@ jobs:
           name: wheels
           path: dist
       - name: pytest
-        if: ${{ !startsWith(matrix.target, 'aarch64') }}
+        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           set -e
+          pip debug --verbose
           pip install hifitime --find-links dist --force-reinstall --no-index -vv
           pip install pytest
           pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -114,7 +114,7 @@ jobs:
           pytest
 
   macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         platform:
@@ -134,16 +134,15 @@ jobs:
           args: --release --out dist --find-interpreter -F python
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.platform.target }}
           path: dist
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           set -e
-          pip debug --verbose
           pip install hifitime --find-links dist --force-reinstall --no-index -vv
           pip install pytest
           pytest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,18 @@ reqwest = { version = "0.12", features = ["blocking", "json"], optional = true }
 tabled = { version = "0.15.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 web-time = { version = "1.0.0", optional = true }
+snafu = { version = "0.8.2", default-features = false }
+
+[features]
+default = ["std"]
+std = ["serde", "serde_derive", "web-time", "snafu/std", "snafu/backtrace"]
+python = ["std", "pyo3", "ut1"]
+ut1 = ["std", "reqwest", "tabled", "openssl"]
+
+[dev-dependencies]
+serde_json = "1.0.91"
+criterion = "0.5.1"
+iai = "0.1"
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = { version = "0.3" }
@@ -62,17 +74,6 @@ web-sys = { version = "0.3", features = [
     'Performance',
     'PerformanceTiming',
 ] }
-
-[dev-dependencies]
-serde_json = "1.0.91"
-criterion = "0.5.1"
-iai = "0.1"
-
-[features]
-default = ["std"]
-std = ["serde", "serde_derive", "web-time"]
-python = ["std", "pyo3", "ut1"]
-ut1 = ["std", "reqwest", "tabled", "openssl"]
 
 [[bench]]
 name = "crit_epoch"

--- a/src/duration/kani_verif.rs
+++ b/src/duration/kani_verif.rs
@@ -10,7 +10,7 @@
 
 // Here lives all of the formal verification for Duration.
 
-use super::{Duration, Errors};
+use super::{Duration, DurationError};
 use crate::NANOSECONDS_PER_CENTURY;
 
 use kani::Arbitrary;
@@ -43,7 +43,7 @@ fn formal_duration_truncated_ns_reciprocity() {
         // Then it does not fit on a i64, so this function should return an error
         assert_eq!(
             dur_from_part.try_truncated_nanoseconds(),
-            Err(Errors::Overflow)
+            Err(DurationError::Overflow)
         );
     } else if centuries == -1 {
         // If we are negative by just enough that the centuries is negative, then the truncated seconds

--- a/src/duration/parse.rs
+++ b/src/duration/parse.rs
@@ -55,6 +55,7 @@ impl FromStr for Duration {
         if s.is_empty() {
             return Err(EpochError::Parse {
                 source: ParsingErrors::NothingToParse,
+                details: "input string is empty",
             });
         }
 
@@ -79,6 +80,7 @@ impl FromStr for Duration {
                     // This invalid
                     return Err(EpochError::Parse {
                         source: ParsingErrors::InvalidTimezone,
+                        details: "invalid timezone format [+/-]HH:MM",
                     });
                 };
 
@@ -88,6 +90,7 @@ impl FromStr for Duration {
                     Err(err) => {
                         return Err(EpochError::Parse {
                             source: ParsingErrors::Lexical { err },
+                            details: "invalid hours",
                         })
                     }
                 };
@@ -106,13 +109,14 @@ impl FromStr for Duration {
                             Err(_) => {
                                 return Err(EpochError::Parse {
                                     source: ParsingErrors::ValueError,
+                                    details: "invalid minute",
                                 })
                             }
                         }
 
                         match s.get(indexes.2 + 2 * colon..) {
                             None => {
-                                // Do nothing, there are no seconds inthis offset
+                                // Do nothing, there are no seconds in this offset
                             }
                             Some(subs) => {
                                 if !subs.is_empty() {
@@ -122,6 +126,7 @@ impl FromStr for Duration {
                                         Err(_) => {
                                             return Err(EpochError::Parse {
                                                 source: ParsingErrors::ValueError,
+                                                details: "invalid seconds",
                                             })
                                         }
                                     }
@@ -151,6 +156,7 @@ impl FromStr for Duration {
                         // We've reached the end of the string and it didn't end with a unit
                         return Err(EpochError::Parse {
                             source: ParsingErrors::UnknownOrMissingUnit,
+                            details: "expect a unit after a numeric",
                         });
                     }
                     // We've found a new space so let's parse whatever precedes it
@@ -159,6 +165,7 @@ impl FromStr for Duration {
                         Err(_) => {
                             return Err(EpochError::Parse {
                                 source: ParsingErrors::ValueError,
+                                details: "could not parse what precedes the space",
                             })
                         }
                     }
@@ -178,6 +185,7 @@ impl FromStr for Duration {
                         _ => {
                             return Err(EpochError::Parse {
                                 source: ParsingErrors::UnknownOrMissingUnit,
+                                details: "unknown unit",
                             });
                         }
                     };

--- a/src/duration/parse.rs
+++ b/src/duration/parse.rs
@@ -9,7 +9,7 @@
 */
 
 use super::{Duration, Unit};
-use crate::{EpochError, ParsingErrors};
+use crate::{EpochError, ParsingError};
 use core::str::FromStr;
 
 impl FromStr for Duration {
@@ -54,7 +54,7 @@ impl FromStr for Duration {
 
         if s.is_empty() {
             return Err(EpochError::Parse {
-                source: ParsingErrors::NothingToParse,
+                source: ParsingError::NothingToParse,
                 details: "input string is empty",
             });
         }
@@ -79,7 +79,7 @@ impl FromStr for Duration {
                 } else {
                     // This invalid
                     return Err(EpochError::Parse {
-                        source: ParsingErrors::InvalidTimezone,
+                        source: ParsingError::InvalidTimezone,
                         details: "invalid timezone format [+/-]HH:MM",
                     });
                 };
@@ -89,7 +89,7 @@ impl FromStr for Duration {
                     Ok(val) => val,
                     Err(err) => {
                         return Err(EpochError::Parse {
-                            source: ParsingErrors::Lexical { err },
+                            source: ParsingError::Lexical { err },
                             details: "invalid hours",
                         })
                     }
@@ -108,7 +108,7 @@ impl FromStr for Duration {
                             Ok(val) => minutes = val,
                             Err(_) => {
                                 return Err(EpochError::Parse {
-                                    source: ParsingErrors::ValueError,
+                                    source: ParsingError::ValueError,
                                     details: "invalid minute",
                                 })
                             }
@@ -125,7 +125,7 @@ impl FromStr for Duration {
                                         Ok(val) => seconds = val,
                                         Err(_) => {
                                             return Err(EpochError::Parse {
-                                                source: ParsingErrors::ValueError,
+                                                source: ParsingError::ValueError,
                                                 details: "invalid seconds",
                                             })
                                         }
@@ -155,7 +155,7 @@ impl FromStr for Duration {
                     if prev_idx == idx {
                         // We've reached the end of the string and it didn't end with a unit
                         return Err(EpochError::Parse {
-                            source: ParsingErrors::UnknownOrMissingUnit,
+                            source: ParsingError::UnknownOrMissingUnit,
                             details: "expect a unit after a numeric",
                         });
                     }
@@ -164,7 +164,7 @@ impl FromStr for Duration {
                         Ok(val) => latest_value = val,
                         Err(_) => {
                             return Err(EpochError::Parse {
-                                source: ParsingErrors::ValueError,
+                                source: ParsingError::ValueError,
                                 details: "could not parse what precedes the space",
                             })
                         }
@@ -184,7 +184,7 @@ impl FromStr for Duration {
                         "ns" | "nanosecond" | "nanoseconds" => 6,
                         _ => {
                             return Err(EpochError::Parse {
-                                source: ParsingErrors::UnknownOrMissingUnit,
+                                source: ParsingError::UnknownOrMissingUnit,
                                 details: "unknown unit",
                             });
                         }

--- a/src/duration/parse.rs
+++ b/src/duration/parse.rs
@@ -9,11 +9,11 @@
 */
 
 use super::{Duration, Unit};
-use crate::{Errors, ParsingErrors};
+use crate::{EpochError, ParsingErrors};
 use core::str::FromStr;
 
 impl FromStr for Duration {
-    type Err = Errors;
+    type Err = EpochError;
 
     /// Attempts to convert a simple string to a Duration. Does not yet support complicated durations.
     ///
@@ -53,7 +53,9 @@ impl FromStr for Duration {
         let s = s_in.trim();
 
         if s.is_empty() {
-            return Err(Errors::ParseError(ParsingErrors::ValueError));
+            return Err(EpochError::Parse {
+                source: ParsingErrors::NothingToParse,
+            });
         }
 
         // There is at least one character, so we can unwrap this.
@@ -75,13 +77,19 @@ impl FromStr for Duration {
                     1
                 } else {
                     // This invalid
-                    return Err(Errors::ParseError(ParsingErrors::ValueError));
+                    return Err(EpochError::Parse {
+                        source: ParsingErrors::InvalidTimezone,
+                    });
                 };
 
                 // Fetch the hours
                 let hours: i64 = match lexical_core::parse(s[indexes.0..indexes.1].as_bytes()) {
                     Ok(val) => val,
-                    Err(_) => return Err(Errors::ParseError(ParsingErrors::ValueError)),
+                    Err(err) => {
+                        return Err(EpochError::Parse {
+                            source: ParsingErrors::Lexical { err },
+                        })
+                    }
                 };
 
                 let mut minutes: i64 = 0;
@@ -95,7 +103,11 @@ impl FromStr for Duration {
                         // Fetch the minutes
                         match lexical_core::parse(subs.as_bytes()) {
                             Ok(val) => minutes = val,
-                            Err(_) => return Err(Errors::ParseError(ParsingErrors::ValueError)),
+                            Err(_) => {
+                                return Err(EpochError::Parse {
+                                    source: ParsingErrors::ValueError,
+                                })
+                            }
                         }
 
                         match s.get(indexes.2 + 2 * colon..) {
@@ -108,9 +120,9 @@ impl FromStr for Duration {
                                     match lexical_core::parse(subs.as_bytes()) {
                                         Ok(val) => seconds = val,
                                         Err(_) => {
-                                            return Err(Errors::ParseError(
-                                                ParsingErrors::ValueError,
-                                            ))
+                                            return Err(EpochError::Parse {
+                                                source: ParsingErrors::ValueError,
+                                            })
                                         }
                                     }
                                 }
@@ -137,12 +149,18 @@ impl FromStr for Duration {
                 if seeking_number {
                     if prev_idx == idx {
                         // We've reached the end of the string and it didn't end with a unit
-                        return Err(Errors::ParseError(ParsingErrors::UnknownOrMissingUnit));
+                        return Err(EpochError::Parse {
+                            source: ParsingErrors::UnknownOrMissingUnit,
+                        });
                     }
                     // We've found a new space so let's parse whatever precedes it
                     match lexical_core::parse(s[prev_idx..idx].as_bytes()) {
                         Ok(val) => latest_value = val,
-                        Err(_) => return Err(Errors::ParseError(ParsingErrors::ValueError)),
+                        Err(_) => {
+                            return Err(EpochError::Parse {
+                                source: ParsingErrors::ValueError,
+                            })
+                        }
                     }
                     // We'll now seek a unit
                     seeking_number = false;
@@ -158,7 +176,9 @@ impl FromStr for Duration {
                         "us" | "microsecond" | "microseconds" => 5,
                         "ns" | "nanosecond" | "nanoseconds" => 6,
                         _ => {
-                            return Err(Errors::ParseError(ParsingErrors::UnknownOrMissingUnit));
+                            return Err(EpochError::Parse {
+                                source: ParsingErrors::UnknownOrMissingUnit,
+                            });
                         }
                     };
                     // Store the value

--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -12,7 +12,7 @@ use snafu::ResultExt;
 
 use super::formatter::Item;
 use crate::errors::ParseSnafu;
-use crate::{parser::Token, ParsingErrors};
+use crate::{parser::Token, ParsingError};
 use crate::{Epoch, EpochError, MonthName, TimeScale, Unit, Weekday};
 use core::fmt;
 use core::str::FromStr;
@@ -163,7 +163,7 @@ impl Format {
             Some(item) => item,
             None => {
                 return Err(EpochError::Parse {
-                    source: ParsingErrors::NothingToParse,
+                    source: ParsingError::NothingToParse,
                     details: "format string contains no tokens",
                 })
             }
@@ -216,7 +216,7 @@ impl Format {
                             || (cur_item.second_sep_char_is_not(char)))
                     {
                         return Err(EpochError::Parse {
-                            source: ParsingErrors::UnexpectedCharacter {
+                            source: ParsingError::UnexpectedCharacter {
                                 found: char,
                                 option1: cur_item.sep_char,
                                 option2: cur_item.second_sep_char,
@@ -248,7 +248,7 @@ impl Format {
                 match prev_token {
                     Token::YearShort => {
                         decomposed[0] = sub_str.parse::<i32>().map_err(|_| EpochError::Parse {
-                            source: ParsingErrors::ValueError,
+                            source: ParsingError::ValueError,
                             details: "could not parse year as i32",
                         })? + 2000;
                     }
@@ -258,7 +258,7 @@ impl Format {
                             Ok(val) => day_of_year = Some(val),
                             Err(_) => {
                                 return Err(EpochError::Parse {
-                                    source: ParsingErrors::ValueError,
+                                    source: ParsingError::ValueError,
                                     details: "could not parse day of year as f64",
                                 })
                             }
@@ -286,7 +286,7 @@ impl Format {
                             }
                             Err(_) => {
                                 return Err(EpochError::Parse {
-                                    source: ParsingErrors::ValueError,
+                                    source: ParsingError::ValueError,
                                     details: "could not parse month name",
                                 })
                             }
@@ -324,7 +324,7 @@ impl Format {
                             }
                             Err(err) => {
                                 return Err(EpochError::Parse {
-                                    source: ParsingErrors::Lexical { err },
+                                    source: ParsingError::Lexical { err },
                                     details: "could not parse numerical",
                                 });
                             }
@@ -375,7 +375,7 @@ impl Format {
             // Check that the weekday is correct
             if weekday != epoch.weekday() {
                 return Err(EpochError::Parse {
-                    source: ParsingErrors::WeekdayMismatch {
+                    source: ParsingError::WeekdayMismatch {
                         found: weekday,
                         expected: epoch.weekday(),
                     },
@@ -410,7 +410,7 @@ impl fmt::Debug for Format {
 }
 
 impl FromStr for Format {
-    type Err = ParsingErrors;
+    type Err = ParsingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut me = Format::default();
         for token in s.split('%') {
@@ -552,7 +552,7 @@ impl FromStr for Format {
                         ));
                         me.num_items += 1;
                     }
-                    _ => return Err(ParsingErrors::UnknownToken { token: char }),
+                    _ => return Err(ParsingError::UnknownToken { token: char }),
                 },
                 None => continue, // We're probably just at the start of the string
             }

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -11,7 +11,7 @@
 use crate::errors::DurationError;
 use crate::parser::Token;
 use crate::{
-    Duration, Epoch, EpochError, ParsingErrors, TimeScale, Unit, DAYS_PER_YEAR_NLD,
+    Duration, Epoch, EpochError, ParsingError, TimeScale, Unit, DAYS_PER_YEAR_NLD,
     HIFITIME_REF_YEAR, NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND,
     NANOSECONDS_PER_SECOND_U32,
 };
@@ -585,7 +585,7 @@ impl Epoch {
 
                 if prev_idx > end_idx {
                     return Err(EpochError::Parse {
-                        source: ParsingErrors::ISO8601,
+                        source: ParsingError::ISO8601,
                         details: "parsing as Gregorian",
                     });
                 }
@@ -608,7 +608,7 @@ impl Epoch {
                     }
                     Err(err) => {
                         return Err(EpochError::Parse {
-                            source: ParsingErrors::Lexical { err },
+                            source: ParsingError::Lexical { err },
                             details: "parsing as Gregorian",
                         })
                     }

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -8,10 +8,12 @@
  * Documentation: https://nyxspace.com/
  */
 
+use crate::errors::DurationError;
 use crate::parser::Token;
 use crate::{
-    Duration, Epoch, Errors, ParsingErrors, TimeScale, Unit, DAYS_PER_YEAR_NLD, HIFITIME_REF_YEAR,
-    NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND, NANOSECONDS_PER_SECOND_U32,
+    Duration, Epoch, EpochError, ParsingErrors, TimeScale, Unit, DAYS_PER_YEAR_NLD,
+    HIFITIME_REF_YEAR, NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND,
+    NANOSECONDS_PER_SECOND_U32,
 };
 use core::str::FromStr;
 
@@ -231,7 +233,7 @@ impl Epoch {
         minute: u8,
         second: u8,
         nanos: u32,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         Self::maybe_from_gregorian(
             year,
             month,
@@ -256,15 +258,23 @@ impl Epoch {
         second: u8,
         nanos: u32,
         time_scale: TimeScale,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         if !is_gregorian_valid(year, month, day, hour, minute, second, nanos) {
-            return Err(Errors::Carry);
+            return Err(EpochError::InvalidGregorianDate);
         }
 
         let mut duration_wrt_ref = match year.checked_sub(HIFITIME_REF_YEAR) {
-            None => return Err(Errors::Overflow),
+            None => {
+                return Err(EpochError::Duration {
+                    source: DurationError::Underflow,
+                })
+            }
             Some(years_since_ref) => match years_since_ref.checked_mul(365) {
-                None => return Err(Errors::Overflow),
+                None => {
+                    return Err(EpochError::Duration {
+                        source: DurationError::Overflow,
+                    })
+                }
                 Some(days) => Unit::Day * i64::from(days),
             },
         } - time_scale.gregorian_epoch_offset();
@@ -369,7 +379,7 @@ impl Epoch {
         minute: u8,
         second: u8,
         nanos: u32,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         Self::maybe_from_gregorian(
             year,
             month,
@@ -530,7 +540,7 @@ impl Epoch {
     /// );
     /// ```
     #[cfg(not(kani))]
-    pub fn from_gregorian_str(s_in: &str) -> Result<Self, Errors> {
+    pub fn from_gregorian_str(s_in: &str) -> Result<Self, EpochError> {
         // All of the integers in a date: year, month, day, hour, minute, second, subsecond, offset hours, offset minutes
 
         let mut decomposed = [0_i32; 9];
@@ -568,7 +578,9 @@ impl Epoch {
                 };
 
                 if prev_idx > end_idx {
-                    return Err(Errors::ParseError(ParsingErrors::ISO8601));
+                    return Err(EpochError::Parse {
+                        source: ParsingErrors::ISO8601,
+                    });
                 }
 
                 match lexical_core::parse(s[prev_idx..end_idx].as_bytes()) {
@@ -587,7 +599,11 @@ impl Epoch {
                             decomposed[pos] = val
                         }
                     }
-                    Err(_) => return Err(Errors::ParseError(ParsingErrors::ISO8601)),
+                    Err(err) => {
+                        return Err(EpochError::Parse {
+                            source: ParsingErrors::Lexical { err },
+                        })
+                    }
                 }
                 prev_idx = idx + 1;
                 // If we are about to parse an hours offset, we need to set the sign now.

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -543,6 +543,10 @@ impl Epoch {
     pub fn from_gregorian_str(s_in: &str) -> Result<Self, EpochError> {
         // All of the integers in a date: year, month, day, hour, minute, second, subsecond, offset hours, offset minutes
 
+        use snafu::ResultExt;
+
+        use crate::errors::ParseSnafu;
+
         let mut decomposed = [0_i32; 9];
         // The parsed time scale, defaults to UTC
         let mut ts = TimeScale::UTC;
@@ -561,7 +565,9 @@ impl Epoch {
                     // Then we match the timescale directly.
                     if idx != s.len() - 1 {
                         // We have some remaining characters, so let's parse those in the only formats we know.
-                        ts = TimeScale::from_str(s[idx..].trim())?;
+                        ts = TimeScale::from_str(s[idx..].trim()).with_context(|_| ParseSnafu {
+                            details: "parsing as Gregorian date with time scale",
+                        })?;
                     }
                     break;
                 }
@@ -580,6 +586,7 @@ impl Epoch {
                 if prev_idx > end_idx {
                     return Err(EpochError::Parse {
                         source: ParsingErrors::ISO8601,
+                        details: "parsing as Gregorian",
                     });
                 }
 
@@ -602,6 +609,7 @@ impl Epoch {
                     Err(err) => {
                         return Err(EpochError::Parse {
                             source: ParsingErrors::Lexical { err },
+                            details: "parsing as Gregorian",
                         })
                     }
                 }

--- a/src/epoch/leap_seconds_file.rs
+++ b/src/epoch/leap_seconds_file.rs
@@ -37,6 +37,7 @@ impl LeapSecondsFile {
             Err(e) => {
                 return Err(EpochError::Parse {
                     source: ParsingErrors::InOut { err: e.kind() },
+                    details: "opening leap seconds file",
                 })
             }
         };
@@ -45,6 +46,7 @@ impl LeapSecondsFile {
         if let Err(e) = f.read_to_string(&mut contents) {
             return Err(EpochError::Parse {
                 source: ParsingErrors::InOut { err: e.kind() },
+                details: "reading leap seconds file",
             });
         }
 
@@ -60,6 +62,7 @@ impl LeapSecondsFile {
                     if data.len() < 2 {
                         return Err(EpochError::Parse {
                             source: ParsingErrors::UnknownFormat,
+                            details: "leap seconds file should have two columns exactly",
                         });
                     }
 
@@ -68,6 +71,7 @@ impl LeapSecondsFile {
                         Err(_) => {
                             return Err(EpochError::Parse {
                                 source: ParsingErrors::ValueError,
+                                details: "first column value is not numeric",
                             })
                         }
                     };
@@ -77,6 +81,7 @@ impl LeapSecondsFile {
                         Err(_) => {
                             return Err(EpochError::Parse {
                                 source: ParsingErrors::ValueError,
+                                details: "second column value is not numeric",
                             })
                         }
                     };

--- a/src/epoch/leap_seconds_file.rs
+++ b/src/epoch/leap_seconds_file.rs
@@ -17,7 +17,7 @@ use core::ops::Index;
 
 use crate::{
     leap_seconds::{LeapSecond, LeapSecondProvider},
-    EpochError, ParsingErrors,
+    EpochError, ParsingError,
 };
 
 #[repr(C)]
@@ -36,7 +36,7 @@ impl LeapSecondsFile {
             Ok(f) => f,
             Err(e) => {
                 return Err(EpochError::Parse {
-                    source: ParsingErrors::InOut { err: e.kind() },
+                    source: ParsingError::InOut { err: e.kind() },
                     details: "opening leap seconds file",
                 })
             }
@@ -45,7 +45,7 @@ impl LeapSecondsFile {
         let mut contents = String::new();
         if let Err(e) = f.read_to_string(&mut contents) {
             return Err(EpochError::Parse {
-                source: ParsingErrors::InOut { err: e.kind() },
+                source: ParsingError::InOut { err: e.kind() },
                 details: "reading leap seconds file",
             });
         }
@@ -61,7 +61,7 @@ impl LeapSecondsFile {
                     let data: Vec<&str> = line.split_whitespace().collect();
                     if data.len() < 2 {
                         return Err(EpochError::Parse {
-                            source: ParsingErrors::UnknownFormat,
+                            source: ParsingError::UnknownFormat,
                             details: "leap seconds file should have two columns exactly",
                         });
                     }
@@ -70,7 +70,7 @@ impl LeapSecondsFile {
                         Ok(val) => val,
                         Err(_) => {
                             return Err(EpochError::Parse {
-                                source: ParsingErrors::ValueError,
+                                source: ParsingError::ValueError,
                                 details: "first column value is not numeric",
                             })
                         }
@@ -80,7 +80,7 @@ impl LeapSecondsFile {
                         Ok(val) => val,
                         Err(_) => {
                             return Err(EpochError::Parse {
-                                source: ParsingErrors::ValueError,
+                                source: ParsingError::ValueError,
                                 details: "second column value is not numeric",
                             })
                         }

--- a/src/epoch/leap_seconds_file.rs
+++ b/src/epoch/leap_seconds_file.rs
@@ -17,7 +17,7 @@ use core::ops::Index;
 
 use crate::{
     leap_seconds::{LeapSecond, LeapSecondProvider},
-    Errors, ParsingErrors,
+    EpochError, ParsingErrors,
 };
 
 #[repr(C)]
@@ -31,15 +31,21 @@ pub struct LeapSecondsFile {
 
 impl LeapSecondsFile {
     /// Builds a leap second provider from the provided Leap Seconds file in IERS format as found on <https://www.ietf.org/timezones/data/leap-seconds.list> .
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, Errors> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, EpochError> {
         let mut f = match File::open(path) {
             Ok(f) => f,
-            Err(e) => return Err(Errors::ParseError(ParsingErrors::IOError(e.kind()))),
+            Err(e) => {
+                return Err(EpochError::Parse {
+                    source: ParsingErrors::InOut { err: e.kind() },
+                })
+            }
         };
 
         let mut contents = String::new();
         if let Err(e) = f.read_to_string(&mut contents) {
-            return Err(Errors::ParseError(ParsingErrors::IOError(e.kind())));
+            return Err(EpochError::Parse {
+                source: ParsingErrors::InOut { err: e.kind() },
+            });
         }
 
         let mut me = Self::default();
@@ -52,17 +58,27 @@ impl LeapSecondsFile {
                     // We have data of interest!
                     let data: Vec<&str> = line.split_whitespace().collect();
                     if data.len() < 2 {
-                        return Err(Errors::ParseError(ParsingErrors::UnknownFormat));
+                        return Err(EpochError::Parse {
+                            source: ParsingErrors::UnknownFormat,
+                        });
                     }
 
                     let timestamp_tai_s: u64 = match lexical_core::parse(data[0].as_bytes()) {
                         Ok(val) => val,
-                        Err(_) => return Err(Errors::ParseError(ParsingErrors::ValueError)),
+                        Err(_) => {
+                            return Err(EpochError::Parse {
+                                source: ParsingErrors::ValueError,
+                            })
+                        }
                     };
 
                     let delta_at: u8 = match lexical_core::parse(data[1].as_bytes()) {
                         Ok(val) => val,
-                        Err(_) => return Err(Errors::ParseError(ParsingErrors::ValueError)),
+                        Err(_) => {
+                            return Err(EpochError::Parse {
+                                source: ParsingErrors::ValueError,
+                            })
+                        }
                     };
 
                     me.data.push(LeapSecond {
@@ -82,7 +98,7 @@ impl LeapSecondsFile {
 #[cfg_attr(feature = "python", pymethods)]
 impl LeapSecondsFile {
     #[new]
-    pub fn __new__(path: String) -> Result<Self, Errors> {
+    pub fn __new__(path: String) -> Result<Self, EpochError> {
         Self::from_path(&path)
     }
 

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -42,7 +42,7 @@ pub use gregorian::is_gregorian_valid;
 use snafu::ResultExt;
 
 #[cfg(not(kani))]
-use crate::ParsingErrors;
+use crate::ParsingError;
 
 #[cfg(kani)]
 use kani::assert;
@@ -1290,7 +1290,7 @@ impl FromStr for Epoch {
         if s.len() < 7 {
             // We need at least seven characters for a valid epoch
             Err(EpochError::Parse {
-                source: ParsingErrors::UnknownFormat,
+                source: ParsingError::UnknownFormat,
                 details: "less than 7 characters",
             })
         } else {
@@ -1317,7 +1317,7 @@ impl FromStr for Epoch {
                 Ok(val) => val,
                 Err(_) => {
                     return Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "parsing as JD, MJD, or SEC",
                     })
                 }
@@ -1330,7 +1330,7 @@ impl FromStr for Epoch {
                     TimeScale::TDB => Ok(Self::from_jde_tdb(value)),
                     TimeScale::UTC => Ok(Self::from_jde_utc(value)),
                     _ => Err(EpochError::Parse {
-                        source: ParsingErrors::UnsupportedTimeSystem,
+                        source: ParsingError::UnsupportedTimeSystem,
                         details: "for Julian Date",
                     }),
                 },
@@ -1340,7 +1340,7 @@ impl FromStr for Epoch {
                         Ok(Self::from_mjd_in_time_scale(value, ts))
                     }
                     _ => Err(EpochError::Parse {
-                        source: ParsingErrors::UnsupportedTimeSystem,
+                        source: ParsingError::UnsupportedTimeSystem,
                         details: "for Modified Julian Date",
                     }),
                 },
@@ -1355,7 +1355,7 @@ impl FromStr for Epoch {
                     }
                 },
                 _ => Err(EpochError::Parse {
-                    source: ParsingErrors::UnknownFormat,
+                    source: ParsingError::UnknownFormat,
                     details: "suffix not understood",
                 }),
             }

--- a/src/epoch/python.rs
+++ b/src/epoch/python.rs
@@ -10,7 +10,7 @@
 
 // Here lives all of the implementations that are only built with the pyhon feature.
 
-use crate::{prelude::Format, Duration, Epoch, Errors, TimeScale};
+use crate::{prelude::Format, Duration, Epoch, EpochError, TimeScale};
 
 use core::str::FromStr;
 
@@ -282,7 +282,7 @@ impl Epoch {
         minute: u8,
         second: u8,
         nanos: u32,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         Self::maybe_from_gregorian_tai(year, month, day, hour, minute, second, nanos)
     }
 
@@ -300,7 +300,7 @@ impl Epoch {
         second: u8,
         nanos: u32,
         time_scale: TimeScale,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         Self::maybe_from_gregorian(year, month, day, hour, minute, second, nanos, time_scale)
     }
 
@@ -367,7 +367,7 @@ impl Epoch {
         minute: u8,
         second: u8,
         nanos: u32,
-    ) -> Result<Self, Errors> {
+    ) -> Result<Self, EpochError> {
         Self::maybe_from_gregorian_utc(year, month, day, hour, minute, second, nanos)
     }
 
@@ -432,9 +432,7 @@ impl Epoch {
     /// Equivalent to `datetime.strftime`, refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options
     fn strftime(&self, format_str: String) -> PyResult<String> {
         use crate::efmt::Formatter;
-        let fmt = Format::from_str(&format_str)
-            .map_err(Errors::ParseError)
-            .map_err(|e| PyErr::from(e))?;
+        let fmt = Format::from_str(&format_str).map_err(|e| PyErr::from(e))?;
         Ok(format!("{}", Formatter::new(*self, fmt)))
     }
 
@@ -470,7 +468,7 @@ impl Epoch {
     }
 
     #[classmethod]
-    fn system_now(_cls: &Bound<'_, PyType>) -> Result<Self, Errors> {
+    fn system_now(_cls: &Bound<'_, PyType>) -> Result<Self, EpochError> {
         Self::now()
     }
 

--- a/src/epoch/python.rs
+++ b/src/epoch/python.rs
@@ -432,7 +432,7 @@ impl Epoch {
     /// Equivalent to `datetime.strftime`, refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options
     fn strftime(&self, format_str: String) -> PyResult<String> {
         use crate::efmt::Formatter;
-        let fmt = Format::from_str(&format_str).map_err(|e| PyErr::from(e))?;
+        let fmt = Format::from_str(&format_str)?;
         Ok(format!("{}", Formatter::new(*self, fmt)))
     }
 

--- a/src/epoch/system_time.rs
+++ b/src/epoch/system_time.rs
@@ -8,17 +8,18 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::{Duration, Epoch, Errors};
+use crate::{Duration, Epoch, EpochError};
 
 /// Converts the webtime Duration into a hifitime Duration.
 ///
 /// Clippy thinks these are the same type, but they aren't.
 #[allow(clippy::unnecessary_fallible_conversions)]
-pub(crate) fn duration_since_unix_epoch() -> Result<Duration, Errors> {
+pub(crate) fn duration_since_unix_epoch() -> Result<Duration, EpochError> {
+    // TODO: Check why there is a map_err and and_then
     web_time::SystemTime::now()
         .duration_since(web_time::SystemTime::UNIX_EPOCH)
-        .map_err(|_| Errors::SystemTimeError)
-        .and_then(|d| d.try_into().map_err(|_| Errors::SystemTimeError))
+        .map_err(|_| EpochError::SystemTimeError)
+        .and_then(|d| d.try_into().map_err(|_| EpochError::SystemTimeError))
 }
 
 // This is in its separate impl far away from the Python feature because pyO3's classmethod does not work with cfg_attr
@@ -28,7 +29,7 @@ impl Epoch {
     /// WARNING: This assumes that the system time returns the time in UTC (which is the case on Linux)
     /// Uses [`std::time::SystemTime::now`](https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.now)
     /// or javascript interop under the hood
-    pub fn now() -> Result<Self, Errors> {
+    pub fn now() -> Result<Self, EpochError> {
         let duration = duration_since_unix_epoch()?;
         Ok(Self::from_unix_duration(duration))
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ pub enum EpochError {
     InvalidGregorianDate,
     #[snafu(display("{source}, {details}"))]
     Parse {
-        source: ParsingErrors,
+        source: ParsingError,
         details: &'static str,
     },
     #[snafu(display("epoch initialization from system time failed"))]
@@ -49,7 +49,7 @@ pub enum DurationError {
 
 #[non_exhaustive]
 #[derive(Debug, Snafu, PartialEq)]
-pub enum ParsingErrors {
+pub enum ParsingError {
     ParseIntError {
         err: ParseIntError,
     },
@@ -83,18 +83,20 @@ pub enum ParsingErrors {
         err: IOError,
     },
     #[cfg(feature = "ut1")]
-    DownloadError(StatusCode),
+    DownloadError {
+        code: StatusCode,
+    },
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{EpochError, ParsingErrors, TimeScale};
+    use crate::{EpochError, ParsingError, TimeScale};
 
     #[test]
     fn enum_eq() {
         // Check the equality compiles (if one compiles, then all asserts will work)
         assert!(EpochError::InvalidGregorianDate == EpochError::InvalidGregorianDate);
-        assert!(ParsingErrors::ISO8601 == ParsingErrors::ISO8601);
+        assert!(ParsingError::ISO8601 == ParsingError::ISO8601);
         assert!(TimeScale::ET == TimeScale::ET);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,18 +26,15 @@ use crate::Weekday;
 #[derive(Debug, Snafu, PartialEq)]
 #[snafu(visibility(pub(crate)))]
 pub enum EpochError {
-    /// Carry is returned when a provided function does not support time carry. For example,
-    /// if a call to `Datetime::new` receives 60 seconds and there are only 59 seconds in the provided
-    /// date time then a Carry Error is returned as the Result.
     InvalidGregorianDate,
-    /// ParseError is returned when a provided string could not be parsed and converted to the desired
-    /// struct (e.g. Datetime).
+    #[snafu(display("{source}, {details}"))]
     Parse {
         source: ParsingErrors,
-        // TODO: Add action
+        details: &'static str,
     },
-    /// Raised if the initialization from system time failed
+    #[snafu(display("epoch initialization from system time failed"))]
     SystemTimeError,
+    #[snafu(display("epoch computation failed because {source}"))]
     Duration {
         source: DurationError,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod efmt;
 mod parser;
 
 pub mod errors;
-pub use errors::{EpochError, ParsingErrors};
+pub use errors::{DurationError, EpochError, ParsingError};
 
 mod epoch;
 pub use epoch::*;
@@ -92,8 +92,8 @@ pub use month::*;
 pub mod prelude {
     pub use crate::efmt::{Format, Formatter};
     pub use crate::{
-        Duration, Epoch, EpochError, Freq, Frequencies, TimeScale, TimeSeries, TimeUnits, Unit,
-        Weekday,
+        Duration, DurationError, Epoch, EpochError, Freq, Frequencies, ParsingError, TimeScale,
+        TimeSeries, TimeUnits, Unit, Weekday,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod efmt;
 mod parser;
 
 pub mod errors;
-pub use errors::{Errors, ParsingErrors};
+pub use errors::{EpochError, ParsingErrors};
 
 mod epoch;
 pub use epoch::*;
@@ -92,7 +92,8 @@ pub use month::*;
 pub mod prelude {
     pub use crate::efmt::{Format, Formatter};
     pub use crate::{
-        Duration, Epoch, Errors, Freq, Frequencies, TimeScale, TimeSeries, TimeUnits, Unit, Weekday,
+        Duration, Epoch, EpochError, Freq, Frequencies, TimeScale, TimeSeries, TimeUnits, Unit,
+        Weekday,
     };
 }
 

--- a/src/month.rs
+++ b/src/month.rs
@@ -8,7 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::ParsingErrors;
+use crate::ParsingError;
 use core::fmt;
 use core::str::FromStr;
 
@@ -44,7 +44,7 @@ impl Default for MonthName {
 }
 
 impl FromStr for MonthName {
-    type Err = ParsingErrors;
+    type Err = ParsingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim() {
             "jan" | "Jan" | "JAN" | "January" | "JANUARY" | "january" => Ok(Self::January),
@@ -59,7 +59,7 @@ impl FromStr for MonthName {
             "oct" | "Oct" | "OCT" | "October" | "OCTOBER" | "october" => Ok(Self::October),
             "nov" | "Nov" | "NOV" | "November" | "NOVEMBER" | "november" => Ok(Self::November),
             "dec" | "Dec" | "DEC" | "December" | "DECEMBER" | "december" => Ok(Self::December),
-            _ => Err(ParsingErrors::UnknownMonthName),
+            _ => Err(ParsingError::UnknownMonthName),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::{EpochError, ParsingErrors};
+use crate::{EpochError, ParsingError};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Token {
@@ -47,7 +47,7 @@ impl Token {
             Self::Month => {
                 if !(0..=13).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid month",
                     })
                 } else {
@@ -57,7 +57,7 @@ impl Token {
             Self::Day => {
                 if !(0..=31).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid day",
                     })
                 } else {
@@ -67,7 +67,7 @@ impl Token {
             Self::Hour | Self::OffsetHours => {
                 if !(0..=23).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid hour",
                     })
                 } else {
@@ -77,7 +77,7 @@ impl Token {
             Self::Minute | Self::OffsetMinutes => {
                 if !(0..=59).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid minutes",
                     })
                 } else {
@@ -87,7 +87,7 @@ impl Token {
             Self::Second => {
                 if !(0..=60).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid seconds",
                     })
                 } else {
@@ -97,7 +97,7 @@ impl Token {
             Self::Subsecond => {
                 if val < 0 {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid subseconds",
                     })
                 } else {
@@ -108,7 +108,7 @@ impl Token {
             Self::DayOfYearInteger => {
                 if !(0..=366).contains(&val) {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::ValueError,
+                        source: ParsingError::ValueError,
                         details: "invalid day of year",
                     })
                 } else {
@@ -125,7 +125,7 @@ impl Token {
             | Self::DayOfYear => {
                 // These cannot be parsed as integers
                 Err(EpochError::Parse {
-                    source: ParsingErrors::ValueError,
+                    source: ParsingError::ValueError,
                     details: "invalid name or day of year",
                 })
             }
@@ -158,7 +158,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid year",
                     })
                 }
@@ -169,7 +169,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid month",
                     })
                 }
@@ -180,7 +180,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid day",
                     })
                 }
@@ -191,7 +191,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid hour",
                     })
                 }
@@ -202,7 +202,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid minutes",
                     })
                 }
@@ -218,7 +218,7 @@ impl Token {
                     *self = Token::OffsetHours;
                 } else {
                     return Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid seconds",
                     });
                 }
@@ -233,7 +233,7 @@ impl Token {
                     *self = Token::OffsetHours;
                 } else {
                     return Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid subseconds",
                     });
                 }
@@ -245,7 +245,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid hours offset",
                     })
                 }
@@ -257,7 +257,7 @@ impl Token {
                     Ok(())
                 } else {
                     Err(EpochError::Parse {
-                        source: ParsingErrors::UnknownFormat,
+                        source: ParsingError::UnknownFormat,
                         details: "invalid minutes offset",
                     })
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,6 +48,7 @@ impl Token {
                 if !(0..=13).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid month",
                     })
                 } else {
                     Ok(())
@@ -57,6 +58,7 @@ impl Token {
                 if !(0..=31).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid day",
                     })
                 } else {
                     Ok(())
@@ -66,6 +68,7 @@ impl Token {
                 if !(0..=23).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid hour",
                     })
                 } else {
                     Ok(())
@@ -75,6 +78,7 @@ impl Token {
                 if !(0..=59).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid minutes",
                     })
                 } else {
                     Ok(())
@@ -84,6 +88,7 @@ impl Token {
                 if !(0..=60).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid seconds",
                     })
                 } else {
                     Ok(())
@@ -93,6 +98,7 @@ impl Token {
                 if val < 0 {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid subseconds",
                     })
                 } else {
                     Ok(())
@@ -103,6 +109,7 @@ impl Token {
                 if !(0..=366).contains(&val) {
                     Err(EpochError::Parse {
                         source: ParsingErrors::ValueError,
+                        details: "invalid day of year",
                     })
                 } else {
                     Ok(())
@@ -119,6 +126,7 @@ impl Token {
                 // These cannot be parsed as integers
                 Err(EpochError::Parse {
                     source: ParsingErrors::ValueError,
+                    details: "invalid name or day of year",
                 })
             }
         }
@@ -151,6 +159,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid year",
                     })
                 }
             }
@@ -161,6 +170,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid month",
                     })
                 }
             }
@@ -171,6 +181,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid day",
                     })
                 }
             }
@@ -181,6 +192,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid hour",
                     })
                 }
             }
@@ -191,6 +203,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid minutes",
                     })
                 }
             }
@@ -206,6 +219,7 @@ impl Token {
                 } else {
                     return Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid seconds",
                     });
                 }
                 Ok(())
@@ -220,6 +234,7 @@ impl Token {
                 } else {
                     return Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid subseconds",
                     });
                 }
                 Ok(())
@@ -231,6 +246,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid hours offset",
                     })
                 }
             }
@@ -242,6 +258,7 @@ impl Token {
                 } else {
                     Err(EpochError::Parse {
                         source: ParsingErrors::UnknownFormat,
+                        details: "invalid minutes offset",
                     })
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::{Errors, ParsingErrors};
+use crate::{EpochError, ParsingErrors};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Token {
@@ -40,48 +40,60 @@ impl Default for Token {
 
 impl Token {
     // Check that the _integer_ value is valid at first sight.
-    pub fn value_ok(&self, val: i32) -> Result<(), Errors> {
+    pub fn value_ok(&self, val: i32) -> Result<(), EpochError> {
         match &self {
             Self::Year => Ok(()),      // No validation
             Self::YearShort => Ok(()), // No validation
             Self::Month => {
                 if !(0..=13).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
             }
             Self::Day => {
                 if !(0..=31).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
             }
             Self::Hour | Self::OffsetHours => {
                 if !(0..=23).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
             }
             Self::Minute | Self::OffsetMinutes => {
                 if !(0..=59).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
             }
             Self::Second => {
                 if !(0..=60).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
             }
             Self::Subsecond => {
                 if val < 0 {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
@@ -89,7 +101,9 @@ impl Token {
             Self::Timescale => Ok(()),
             Self::DayOfYearInteger => {
                 if !(0..=366).contains(&val) {
-                    Err(Errors::ParseError(ParsingErrors::ValueError))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::ValueError,
+                    })
                 } else {
                     Ok(())
                 }
@@ -103,7 +117,9 @@ impl Token {
             | Self::MonthNameShort
             | Self::DayOfYear => {
                 // These cannot be parsed as integers
-                Err(Errors::ParseError(ParsingErrors::ValueError))
+                Err(EpochError::Parse {
+                    source: ParsingErrors::ValueError,
+                })
             }
         }
     }
@@ -126,14 +142,16 @@ impl Token {
 
     /// Updates the token to what it should be seeking next given the delimiting character
     /// and returns the position in the array where the parsed integer should live
-    pub fn advance_with(&mut self, ending_char: char) -> Result<(), Errors> {
+    pub fn advance_with(&mut self, ending_char: char) -> Result<(), EpochError> {
         match &self {
             Token::Year | Token::YearShort => {
                 if ending_char == '-' {
                     *self = Token::Month;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::Month => {
@@ -141,7 +159,9 @@ impl Token {
                     *self = Token::Day;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::Day => {
@@ -149,7 +169,9 @@ impl Token {
                     *self = Token::Hour;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::Hour => {
@@ -157,7 +179,9 @@ impl Token {
                     *self = Token::Minute;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::Minute => {
@@ -165,7 +189,9 @@ impl Token {
                     *self = Token::Second;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::Second => {
@@ -178,7 +204,9 @@ impl Token {
                     // There are no subseconds here, but we're seeing the start of an offset
                     *self = Token::OffsetHours;
                 } else {
-                    return Err(Errors::ParseError(ParsingErrors::UnknownFormat));
+                    return Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    });
                 }
                 Ok(())
             }
@@ -190,7 +218,9 @@ impl Token {
                     // There are no subseconds here, but we're seeing the start of an offset
                     *self = Token::OffsetHours;
                 } else {
-                    return Err(Errors::ParseError(ParsingErrors::UnknownFormat));
+                    return Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    });
                 }
                 Ok(())
             }
@@ -199,7 +229,9 @@ impl Token {
                     *self = Token::OffsetMinutes;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             Token::OffsetMinutes => {
@@ -208,7 +240,9 @@ impl Token {
                     *self = Token::Timescale;
                     Ok(())
                 } else {
-                    Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+                    Err(EpochError::Parse {
+                        source: ParsingErrors::UnknownFormat,
+                    })
                 }
             }
             _ => Ok(()),

--- a/src/python.rs
+++ b/src/python.rs
@@ -8,37 +8,11 @@
  * Documentation: https://nyxspace.com/
  */
 
-use core::fmt;
 use pyo3::{exceptions::PyException, prelude::*};
 
 use crate::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
 use crate::prelude::*;
 use crate::ut1::Ut1Provider;
-
-#[derive(Debug)]
-#[repr(C)]
-#[cfg_attr(feature = "python", pyclass)]
-pub enum Exceptions {
-    EpochError { err: String },
-    ParsingError { err: String },
-    DurationError { err: String },
-}
-
-impl fmt::Display for Exceptions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::EpochError { err } => write!(f, "{err}"),
-            Self::DurationError { err } => write!(f, "{err}"),
-            Self::ParsingError { err } => write!(f, "{err}"),
-        }
-    }
-}
-
-impl From<Exceptions> for PyErr {
-    fn from(err: Exceptions) -> PyErr {
-        PyException::new_err(err.to_string())
-    }
-}
 
 impl From<EpochError> for PyErr {
     fn from(err: EpochError) -> PyErr {
@@ -58,34 +32,9 @@ impl From<DurationError> for PyErr {
     }
 }
 
-impl From<EpochError> for Exceptions {
-    fn from(err: EpochError) -> Exceptions {
-        Exceptions::EpochError {
-            err: err.to_string(),
-        }
-    }
-}
-
-impl From<ParsingError> for Exceptions {
-    fn from(err: ParsingError) -> Exceptions {
-        Exceptions::ParsingError {
-            err: err.to_string(),
-        }
-    }
-}
-
-impl From<DurationError> for Exceptions {
-    fn from(err: DurationError) -> Exceptions {
-        Exceptions::DurationError {
-            err: err.to_string(),
-        }
-    }
-}
-
 #[pymodule]
 fn hifitime(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Epoch>()?;
-    m.add_class::<Exceptions>()?;
     m.add_class::<TimeScale>()?;
     m.add_class::<TimeSeries>()?;
     m.add_class::<Duration>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -8,35 +8,84 @@
  * Documentation: https://nyxspace.com/
  */
 
+use core::fmt;
 use pyo3::{exceptions::PyException, prelude::*};
 
-use crate::prelude::*;
-
 use crate::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
-
+use crate::prelude::*;
 use crate::ut1::Ut1Provider;
 
-impl std::convert::From<EpochError> for PyErr {
+#[derive(Debug)]
+#[repr(C)]
+#[cfg_attr(feature = "python", pyclass)]
+pub enum Exceptions {
+    EpochError { err: String },
+    ParsingError { err: String },
+    DurationError { err: String },
+}
+
+impl fmt::Display for Exceptions {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::EpochError { err } => write!(f, "{err}"),
+            Self::DurationError { err } => write!(f, "{err}"),
+            Self::ParsingError { err } => write!(f, "{err}"),
+        }
+    }
+}
+
+impl From<Exceptions> for PyErr {
+    fn from(err: Exceptions) -> PyErr {
+        PyException::new_err(err.to_string())
+    }
+}
+
+impl From<EpochError> for PyErr {
     fn from(err: EpochError) -> PyErr {
         PyException::new_err(err.to_string())
     }
 }
 
-impl std::convert::From<ParsingError> for PyErr {
+impl From<ParsingError> for PyErr {
     fn from(err: ParsingError) -> PyErr {
         PyException::new_err(err.to_string())
     }
 }
 
-impl std::convert::From<DurationError> for PyErr {
+impl From<DurationError> for PyErr {
     fn from(err: DurationError) -> PyErr {
         PyException::new_err(err.to_string())
+    }
+}
+
+impl From<EpochError> for Exceptions {
+    fn from(err: EpochError) -> Exceptions {
+        Exceptions::EpochError {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<ParsingError> for Exceptions {
+    fn from(err: ParsingError) -> Exceptions {
+        Exceptions::ParsingError {
+            err: err.to_string(),
+        }
+    }
+}
+
+impl From<DurationError> for Exceptions {
+    fn from(err: DurationError) -> Exceptions {
+        Exceptions::DurationError {
+            err: err.to_string(),
+        }
     }
 }
 
 #[pymodule]
 fn hifitime(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Epoch>()?;
+    m.add_class::<Exceptions>()?;
     m.add_class::<TimeScale>()?;
     m.add_class::<TimeSeries>()?;
     m.add_class::<Duration>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -16,8 +16,20 @@ use crate::leap_seconds::{LatestLeapSeconds, LeapSecondsFile};
 
 use crate::ut1::Ut1Provider;
 
-impl std::convert::From<Errors> for PyErr {
-    fn from(err: Errors) -> PyErr {
+impl std::convert::From<EpochError> for PyErr {
+    fn from(err: EpochError) -> PyErr {
+        PyException::new_err(err.to_string())
+    }
+}
+
+impl std::convert::From<ParsingError> for PyErr {
+    fn from(err: ParsingError) -> PyErr {
+        PyException::new_err(err.to_string())
+    }
+}
+
+impl std::convert::From<DurationError> for PyErr {
+    fn from(err: DurationError) -> PyErr {
         PyException::new_err(err.to_string())
     }
 }

--- a/src/timescale/fmt.rs
+++ b/src/timescale/fmt.rs
@@ -11,7 +11,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use crate::ParsingErrors;
+use crate::ParsingError;
 
 use super::TimeScale;
 
@@ -47,7 +47,7 @@ impl fmt::LowerHex for TimeScale {
 }
 
 impl FromStr for TimeScale {
-    type Err = ParsingErrors;
+    type Err = ParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val = s.trim();
@@ -70,7 +70,7 @@ impl FromStr for TimeScale {
         } else if val == "QZSST" || val == "QZSS" {
             Ok(Self::QZSST)
         } else {
-            Err(ParsingErrors::TimeSystem)
+            Err(ParsingError::TimeSystem)
         }
     }
 }

--- a/src/timescale/fmt.rs
+++ b/src/timescale/fmt.rs
@@ -11,7 +11,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use crate::{EpochError, ParsingErrors};
+use crate::ParsingErrors;
 
 use super::TimeScale;
 
@@ -47,7 +47,7 @@ impl fmt::LowerHex for TimeScale {
 }
 
 impl FromStr for TimeScale {
-    type Err = EpochError;
+    type Err = ParsingErrors;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val = s.trim();
@@ -70,9 +70,7 @@ impl FromStr for TimeScale {
         } else if val == "QZSST" || val == "QZSS" {
             Ok(Self::QZSST)
         } else {
-            Err(EpochError::Parse {
-                source: ParsingErrors::TimeSystem,
-            })
+            Err(ParsingErrors::TimeSystem)
         }
     }
 }

--- a/src/timescale/fmt.rs
+++ b/src/timescale/fmt.rs
@@ -11,7 +11,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use crate::{Errors, ParsingErrors};
+use crate::{EpochError, ParsingErrors};
 
 use super::TimeScale;
 
@@ -47,7 +47,7 @@ impl fmt::LowerHex for TimeScale {
 }
 
 impl FromStr for TimeScale {
-    type Err = Errors;
+    type Err = EpochError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let val = s.trim();
@@ -70,7 +70,9 @@ impl FromStr for TimeScale {
         } else if val == "QZSST" || val == "QZSS" {
             Ok(Self::QZSST)
         } else {
-            Err(Errors::ParseError(ParsingErrors::TimeSystem))
+            Err(EpochError::Parse {
+                source: ParsingErrors::TimeSystem,
+            })
         }
     }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -8,7 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
-use crate::{Duration, ParsingErrors, Unit};
+use crate::{Duration, ParsingError, Unit};
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::str::FromStr;
@@ -90,7 +90,7 @@ impl From<Weekday> for u8 {
 }
 
 impl FromStr for Weekday {
-    type Err = ParsingErrors;
+    type Err = ParsingError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim() {
             "mon" | "Mon" | "MON" | "monday" | "Monday" | "MONDAY" => Ok(Self::Monday),
@@ -100,7 +100,7 @@ impl FromStr for Weekday {
             "fri" | "Fri" | "FRI" | "friday" | "Friday" | "FRIDAY" => Ok(Self::Friday),
             "sat" | "Sat" | "SAT" | "saturday" | "Saturday" | "SATURDAY" => Ok(Self::Saturday),
             "sun" | "Sun" | "SUN" | "sunday" | "Sunday" | "SUNDAY" => Ok(Self::Sunday),
-            _ => Err(ParsingErrors::UnknownWeekday),
+            _ => Err(ParsingError::UnknownWeekday),
         }
     }
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,6 +1,5 @@
 use hifitime::{
-    Duration, EpochError, Freq, Frequencies, ParsingErrors, TimeUnits, Unit,
-    NANOSECONDS_PER_CENTURY, NANOSECONDS_PER_MINUTE,
+    Duration, Freq, Frequencies, TimeUnits, Unit, NANOSECONDS_PER_CENTURY, NANOSECONDS_PER_MINUTE,
 };
 
 #[cfg(feature = "std")]
@@ -447,18 +446,12 @@ fn duration_from_str() {
     );
 
     assert!(
-        Duration::from_str("5 days 1")
-            == Err(EpochError::Parse {
-                source: ParsingErrors::UnknownOrMissingUnit
-            }),
+        Duration::from_str("5 days 1").is_err(),
         "should return an unknown unit error"
     );
 
     assert!(
-        Duration::from_str("5 days 1 ")
-            == Err(EpochError::Parse {
-                source: ParsingErrors::UnknownOrMissingUnit
-            }),
+        Duration::from_str("5 days 1 ").is_err(),
         "should return an unknown unit error"
     );
 
@@ -519,19 +512,8 @@ fn duration_from_str() {
         -(1 * Unit::Hour + 15 * Unit::Minute)
     );
 
-    assert_eq!(
-        Duration::from_str(""),
-        Err(EpochError::Parse {
-            source: ParsingErrors::ValueError
-        })
-    );
-
-    assert_eq!(
-        Duration::from_str("+"),
-        Err(EpochError::Parse {
-            source: ParsingErrors::ValueError
-        })
-    );
+    assert!(Duration::from_str("").is_err(),);
+    assert!(Duration::from_str("+").is_err(),);
 }
 
 #[cfg(feature = "std")]

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,6 +1,6 @@
 use hifitime::{
-    Duration, Errors, Freq, Frequencies, ParsingErrors, TimeUnits, Unit, NANOSECONDS_PER_CENTURY,
-    NANOSECONDS_PER_MINUTE,
+    Duration, EpochError, Freq, Frequencies, ParsingErrors, TimeUnits, Unit,
+    NANOSECONDS_PER_CENTURY, NANOSECONDS_PER_MINUTE,
 };
 
 #[cfg(feature = "std")]
@@ -448,13 +448,17 @@ fn duration_from_str() {
 
     assert!(
         Duration::from_str("5 days 1")
-            == Err(Errors::ParseError(ParsingErrors::UnknownOrMissingUnit)),
+            == Err(EpochError::Parse {
+                source: ParsingErrors::UnknownOrMissingUnit
+            }),
         "should return an unknown unit error"
     );
 
     assert!(
         Duration::from_str("5 days 1 ")
-            == Err(Errors::ParseError(ParsingErrors::UnknownOrMissingUnit)),
+            == Err(EpochError::Parse {
+                source: ParsingErrors::UnknownOrMissingUnit
+            }),
         "should return an unknown unit error"
     );
 
@@ -517,12 +521,16 @@ fn duration_from_str() {
 
     assert_eq!(
         Duration::from_str(""),
-        Err(Errors::ParseError(ParsingErrors::ValueError))
+        Err(EpochError::Parse {
+            source: ParsingErrors::ValueError
+        })
     );
 
     assert_eq!(
         Duration::from_str("+"),
-        Err(Errors::ParseError(ParsingErrors::ValueError))
+        Err(EpochError::Parse {
+            source: ParsingErrors::ValueError
+        })
     );
 }
 

--- a/tests/efmt.rs
+++ b/tests/efmt.rs
@@ -85,7 +85,7 @@ fn epoch_format_rfc2822() {
     assert_eq!(
         RFC2822.parse("Fri, 07 Feb 2015 11:22:33"),
         Err(EpochError::Parse {
-            source: hifitime::ParsingErrors::WeekdayMismatch {
+            source: hifitime::ParsingError::WeekdayMismatch {
                 found: Weekday::Friday,
                 expected: Weekday::Saturday
             },

--- a/tests/efmt.rs
+++ b/tests/efmt.rs
@@ -84,12 +84,12 @@ fn epoch_format_rfc2822() {
     // Ensure that we check the weekday is valid.
     assert_eq!(
         RFC2822.parse("Fri, 07 Feb 2015 11:22:33"),
-        Err(Errors::ParseError(
-            hifitime::ParsingErrors::WeekdayMismatch {
+        Err(EpochError::Parse {
+            source: hifitime::ParsingErrors::WeekdayMismatch {
                 found: Weekday::Friday,
                 expected: Weekday::Saturday
             }
-        ))
+        })
     );
 
     // In RFC2822, only the seconds are displayed, so adding microseconds here won't change the output

--- a/tests/efmt.rs
+++ b/tests/efmt.rs
@@ -88,7 +88,8 @@ fn epoch_format_rfc2822() {
             source: hifitime::ParsingErrors::WeekdayMismatch {
                 found: Weekday::Friday,
                 expected: Weekday::Saturday
-            }
+            },
+            details: "weekday and day number do not match"
         })
     );
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -926,7 +926,8 @@ fn test_from_str() {
     assert_eq!(
         Epoch::from_str("blah"),
         Err(EpochError::Parse {
-            source: ParsingErrors::UnknownFormat
+            source: ParsingErrors::UnknownFormat,
+            details: "less than 7 characters"
         })
     );
 }

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2,7 +2,7 @@
 extern crate core;
 
 use hifitime::{
-    is_gregorian_valid, Duration, Epoch, Errors, ParsingErrors, TimeScale, TimeUnits, Unit,
+    is_gregorian_valid, Duration, Epoch, EpochError, ParsingErrors, TimeScale, TimeUnits, Unit,
     Weekday, BDT_REF_EPOCH, DAYS_GPS_TAI_OFFSET, DAYS_PER_YEAR, GPST_REF_EPOCH, GST_REF_EPOCH,
     J1900_OFFSET, J1900_REF_EPOCH, J2000_OFFSET, J2000_REF_EPOCH, J2000_TO_J1900_DURATION,
     MJD_OFFSET, SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET,
@@ -925,7 +925,9 @@ fn test_from_str() {
 
     assert_eq!(
         Epoch::from_str("blah"),
-        Err(Errors::ParseError(ParsingErrors::UnknownFormat))
+        Err(EpochError::Parse {
+            source: ParsingErrors::UnknownFormat
+        })
     );
 }
 
@@ -1904,7 +1906,7 @@ fn test_epoch_formatter() {
     // Test an invalid token
     assert_eq!(
         Format::from_str("%p"),
-        Err(hifitime::ParsingErrors::UnknownFormattingToken('p'))
+        Err(hifitime::ParsingErrors::UnknownToken { token: 'p' })
     );
 }
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2,7 +2,7 @@
 extern crate core;
 
 use hifitime::{
-    is_gregorian_valid, Duration, Epoch, EpochError, ParsingErrors, TimeScale, TimeUnits, Unit,
+    is_gregorian_valid, Duration, Epoch, EpochError, ParsingError, TimeScale, TimeUnits, Unit,
     Weekday, BDT_REF_EPOCH, DAYS_GPS_TAI_OFFSET, DAYS_PER_YEAR, GPST_REF_EPOCH, GST_REF_EPOCH,
     J1900_OFFSET, J1900_REF_EPOCH, J2000_OFFSET, J2000_REF_EPOCH, J2000_TO_J1900_DURATION,
     MJD_OFFSET, SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET,
@@ -926,7 +926,7 @@ fn test_from_str() {
     assert_eq!(
         Epoch::from_str("blah"),
         Err(EpochError::Parse {
-            source: ParsingErrors::UnknownFormat,
+            source: ParsingError::UnknownFormat,
             details: "less than 7 characters"
         })
     );
@@ -1907,7 +1907,7 @@ fn test_epoch_formatter() {
     // Test an invalid token
     assert_eq!(
         Format::from_str("%p"),
-        Err(hifitime::ParsingErrors::UnknownToken { token: 'p' })
+        Err(hifitime::ParsingError::UnknownToken { token: 'p' })
     );
 }
 

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -1,5 +1,5 @@
 extern crate hifitime;
-use hifitime::{Errors, ParsingErrors, TimeScale};
+use hifitime::{EpochError, ParsingErrors, TimeScale};
 use std::str::FromStr;
 
 #[test]
@@ -47,7 +47,9 @@ fn test_from_rinex_format() {
     // Check error
     assert_eq!(
         TimeScale::from_str("FAK"),
-        Err(Errors::ParseError(ParsingErrors::TimeSystem))
+        Err(EpochError::Parse {
+            source: ParsingErrors::TimeSystem
+        })
     );
 }
 

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -1,5 +1,5 @@
 extern crate hifitime;
-use hifitime::{ParsingErrors, TimeScale};
+use hifitime::{ParsingError, TimeScale};
 use std::str::FromStr;
 
 #[test]
@@ -45,7 +45,7 @@ fn test_from_rinex_format() {
     assert_eq!(TimeScale::from_str("BDS"), Ok(TimeScale::BDT));
     assert_eq!(TimeScale::from_str("QZSS"), Ok(TimeScale::QZSST));
     // Check error
-    assert_eq!(TimeScale::from_str("FAK"), Err(ParsingErrors::TimeSystem));
+    assert_eq!(TimeScale::from_str("FAK"), Err(ParsingError::TimeSystem));
 }
 
 #[test]

--- a/tests/timescale.rs
+++ b/tests/timescale.rs
@@ -1,5 +1,5 @@
 extern crate hifitime;
-use hifitime::{EpochError, ParsingErrors, TimeScale};
+use hifitime::{ParsingErrors, TimeScale};
 use std::str::FromStr;
 
 #[test]
@@ -45,12 +45,7 @@ fn test_from_rinex_format() {
     assert_eq!(TimeScale::from_str("BDS"), Ok(TimeScale::BDT));
     assert_eq!(TimeScale::from_str("QZSS"), Ok(TimeScale::QZSST));
     // Check error
-    assert_eq!(
-        TimeScale::from_str("FAK"),
-        Err(EpochError::Parse {
-            source: ParsingErrors::TimeSystem
-        })
-    );
+    assert_eq!(TimeScale::from_str("FAK"), Err(ParsingErrors::TimeSystem));
 }
 
 #[test]

--- a/tests/weekday.rs
+++ b/tests/weekday.rs
@@ -3,7 +3,7 @@ extern crate core;
 
 use core::str::FromStr;
 
-use hifitime::{Duration, Epoch, ParsingErrors, TimeUnits, Unit, Weekday};
+use hifitime::{Duration, Epoch, ParsingError, TimeUnits, Unit, Weekday};
 
 #[test]
 fn test_basic_ops() {
@@ -288,8 +288,5 @@ fn test_formatting() {
 fn test_from_str() {
     use core::str::FromStr;
 
-    assert_eq!(
-        Weekday::from_str("fake"),
-        Err(ParsingErrors::UnknownWeekday)
-    );
+    assert_eq!(Weekday::from_str("fake"), Err(ParsingError::UnknownWeekday));
 }


### PR DESCRIPTION
This PR adds `snafu` for error handling. The error messages are more precise, provide more context than the previous ones, and specific type errors are handled in their own error structs. All error structs are marked as non-exhaustive to allow for expanding at a latter date.

I'd like to have the same errors be available from Python, but I'm waiting to hear back from https://github.com/PyO3/pyo3/discussions/4165 for implementation recommendations.

Closes #245 .