### PR TITLE
Breaking change: renamed Julian date constants and removed other Julian date constants

### DIFF
--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -33,8 +33,7 @@ use crate::leap_seconds::{LatestLeapSeconds, LeapSecondProvider};
 use crate::Weekday;
 use crate::{
     EpochError, MonthName, TimeScale, TimeUnits, BDT_REF_EPOCH, ET_EPOCH_S, GPST_REF_EPOCH,
-    GST_REF_EPOCH, J1900_OFFSET, J2000_TO_J1900_DURATION, MJD_OFFSET, NANOSECONDS_PER_DAY,
-    QZSST_REF_EPOCH, UNIX_REF_EPOCH,
+    GST_REF_EPOCH, MJD_J1900, MJD_OFFSET, NANOSECONDS_PER_DAY, QZSST_REF_EPOCH, UNIX_REF_EPOCH,
 };
 use core::cmp::Eq;
 use core::str::FromStr;
@@ -356,7 +355,7 @@ impl Epoch {
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self::from_tai_duration((days - J1900_OFFSET) * Unit::Day)
+        Self::from_tai_duration((days - MJD_J1900) * Unit::Day)
     }
 
     fn from_mjd_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
@@ -396,7 +395,7 @@ impl Epoch {
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self::from_tai_duration((days - J1900_OFFSET - MJD_OFFSET) * Unit::Day)
+        Self::from_tai_duration((days - MJD_J1900 - MJD_OFFSET) * Unit::Day)
     }
 
     fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
@@ -820,7 +819,7 @@ impl Epoch {
     #[must_use]
     /// Returns this epoch as a duration in the requested units in MJD TAI
     pub fn to_mjd_tai(&self, unit: Unit) -> f64 {
-        (self.to_tai_duration() + Unit::Day * J1900_OFFSET).to_unit(unit)
+        (self.to_tai_duration() + Unit::Day * MJD_J1900).to_unit(unit)
     }
 
     #[must_use]
@@ -832,7 +831,7 @@ impl Epoch {
     #[must_use]
     /// Returns the Modified Julian Date in the provided unit in UTC.
     pub fn to_mjd_utc(&self, unit: Unit) -> f64 {
-        (self.to_utc_duration() + Unit::Day * J1900_OFFSET).to_unit(unit)
+        (self.to_utc_duration() + Unit::Day * MJD_J1900).to_unit(unit)
     }
 
     #[must_use]
@@ -858,7 +857,7 @@ impl Epoch {
     #[must_use]
     /// Returns the Julian Days from epoch 01 Jan -4713 12:00 (noon) as a Duration
     pub fn to_jde_tai_duration(&self) -> Duration {
-        self.to_tai_duration() + Unit::Day * J1900_OFFSET + Unit::Day * MJD_OFFSET
+        self.to_tai_duration() + Unit::Day * MJD_J1900 + Unit::Day * MJD_OFFSET
     }
 
     #[must_use]
@@ -876,7 +875,7 @@ impl Epoch {
     #[must_use]
     /// Returns the Julian days in UTC as a `Duration`
     pub fn to_jde_utc_duration(&self) -> Duration {
-        self.to_utc_duration() + Unit::Day * (J1900_OFFSET + MJD_OFFSET)
+        self.to_utc_duration() + Unit::Day * (MJD_J1900 + MJD_OFFSET)
     }
 
     #[must_use]
@@ -923,7 +922,7 @@ impl Epoch {
 
     #[must_use]
     pub fn to_jde_tt_duration(&self) -> Duration {
-        self.to_tt_duration() + Unit::Day * (J1900_OFFSET + MJD_OFFSET)
+        self.to_tt_duration() + Unit::Day * (MJD_J1900 + MJD_OFFSET)
     }
 
     #[must_use]
@@ -934,7 +933,7 @@ impl Epoch {
 
     #[must_use]
     pub fn to_mjd_tt_duration(&self) -> Duration {
-        self.to_tt_duration() + Unit::Day * J1900_OFFSET
+        self.to_tt_duration() + Unit::Day * MJD_J1900
     }
 
     #[must_use]
@@ -1076,13 +1075,6 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Returns the Ephemeris Time in duration past 1900 JAN 01 at noon.
-    /// **Only** use this if the subsequent computation expect J1900 seconds.
-    pub fn to_et_duration_since_j1900(&self) -> Duration {
-        self.to_et_duration() + J2000_TO_J1900_DURATION
-    }
-
-    #[must_use]
     /// Returns the duration between J2000 and the current epoch as per NAIF SPICE.
     ///
     /// # Warning
@@ -1121,13 +1113,6 @@ impl Epoch {
     }
 
     #[must_use]
-    /// Returns the Dynamics Barycentric Time (TDB) as a high precision Duration with reference epoch of 1900 JAN 01 at noon.
-    /// **Only** use this if the subsequent computation expect J1900 seconds.
-    pub fn to_tdb_duration_since_j1900(&self) -> Duration {
-        self.to_tdb_duration() + J2000_TO_J1900_DURATION
-    }
-
-    #[must_use]
     /// Returns the Ephemeris Time JDE past epoch
     pub fn to_jde_et_days(&self) -> f64 {
         self.to_jde_et_duration().to_unit(Unit::Day)
@@ -1136,7 +1121,7 @@ impl Epoch {
     #[must_use]
     pub fn to_jde_et_duration(&self) -> Duration {
         self.to_et_duration()
-            + Unit::Day * (J1900_OFFSET + MJD_OFFSET)
+            + Unit::Day * (MJD_J1900 + MJD_OFFSET)
             + TimeScale::ET.prime_epoch_offset()
     }
 
@@ -1148,7 +1133,7 @@ impl Epoch {
     #[must_use]
     pub fn to_jde_tdb_duration(&self) -> Duration {
         self.to_tdb_duration()
-            + Unit::Day * (J1900_OFFSET + MJD_OFFSET)
+            + Unit::Day * (MJD_J1900 + MJD_OFFSET)
             + TimeScale::TDB.prime_epoch_offset()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,25 +10,18 @@
  * Documentation: https://nyxspace.com/
  */
 
-pub const J1900_NAIF: f64 = 2_415_020.0;
-pub const J2000_NAIF: f64 = 2_451_545.0;
-/// `J1900_OFFSET` determines the offset in julian days between 01 Jan 1900 at midnight and the
-/// Modified Julian Day at 17 November 1858.
-/// NOTE: Julian days "start" at noon so that astronomical observations throughout the night
-/// happen at the same Julian day. Note however that the Modified Julian Date (MJD) starts at
-/// midnight, not noon, cf. <http://tycho.usno.navy.mil/mjd.html>.
-pub const J1900_OFFSET: f64 = 15_020.0;
-/// `J2000_OFFSET` determines the offset in julian days between 01 Jan 2000 at **noon** and the
-/// Modified Julian Day at 17 November 1858.
-pub const J2000_OFFSET: f64 = 51_544.5;
+/// Julian date for the J1900 epoch, as per NAIF SPICE.
+pub const JD_J1900: f64 = 2_415_020.0;
+/// Julian date for the J2000 epoch, as per NAIF SPICE.
+pub const JD_J2000: f64 = 2_451_545.0;
+/// Julian days between 01 Jan 1900 at midnight and the Modified Julian Day at 17 November 1858.
+pub const MJD_J1900: f64 = 15_020.0;
+/// Julian days between 01 Jan 2000 at **noon** and the Modified Julian Day at 17 November 1858.
+pub const MJD_J2000: f64 = 51_544.5;
 /// The Ephemeris Time epoch, in seconds
 pub const ET_EPOCH_S: i64 = 3_155_716_800;
 /// Modified Julian Date in seconds as defined [here](http://tycho.usno.navy.mil/mjd.html). MJD epoch is Modified Julian Day at 17 November 1858 at midnight.
 pub const MJD_OFFSET: f64 = 2_400_000.5;
-/// The JDE offset in days
-pub const JDE_OFFSET_DAYS: f64 = J1900_OFFSET + MJD_OFFSET;
-/// The JDE offset in seconds
-pub const JDE_OFFSET_SECONDS: f64 = JDE_OFFSET_DAYS * SECONDS_PER_DAY;
 /// `DAYS_PER_YEAR` corresponds to the number of days per year in the Julian calendar.
 pub const DAYS_PER_YEAR: f64 = 365.25;
 /// `DAYS_PER_YEAR_NLD` corresponds to the number of days per year **without leap days**.
@@ -54,12 +47,6 @@ pub const SECONDS_PER_YEAR_I64: i64 = 31_557_600;
 pub const SECONDS_PER_TROPICAL_YEAR: f64 = 31_556_925.974_7;
 /// `SECONDS_PER_SIDEREAL_YEAR` corresponds to the number of seconds per sidereal year from [NIST](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9#TIME).
 pub const SECONDS_PER_SIDEREAL_YEAR: f64 = 31_558_150.0;
-
-/// The duration between J2000 and J1900 is exactly one century, both references start at noon.
-pub const J2000_TO_J1900_DURATION: Duration = Duration {
-    centuries: 1,
-    nanoseconds: 0,
-};
 
 // Epoch formatting module is called `efmt` to avoid collision with `std::fmt` and `core::fmt`.
 pub mod efmt;

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2039,6 +2039,7 @@ fn regression_test_gh_209() {
     println!("{t}");
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn regression_test_gh_282() {
     assert_eq!(


### PR DESCRIPTION
Added a regression test to ensure that the printing of dates initialized from MJD is as expected. Clarified in the test that Hifitime's "prime epoch" is at midnight on 1900-01-01, so 0.5 days off of J1900. This behavior matches NAIF SPICE, which is an important property of hifitime as it is used to replace SPICE for time computations.

Renamed the following constants
- J1900_NAIF -> JD_J1900
- J2000_NAIF -> JD_J2000
- J1900_OFFSET -> MJD_J1900
- J2000_OFFSET -> MJD_J12000

Removed constants (unused):
- J2000_TO_J1900_DURATION
- JDE_OFFSET_DAYS
- JDE_OFFSET_SECONDS

Closes #282 