### PR TITLE
Fix bug in `to_gregorian_str` 

### DIFF
--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -145,7 +145,7 @@ impl Epoch {
     /// Converts the Epoch to Gregorian in the provided time scale and in the ISO8601 format with the time scale appended to the string
     pub fn to_gregorian_str(&self, time_scale: TimeScale) -> String {
         let (y, mm, dd, hh, min, s, nanos) =
-            Self::compute_gregorian(self.duration, self.time_scale);
+            Self::compute_gregorian(self.to_duration_in_time_scale(time_scale), time_scale);
 
         if nanos == 0 {
             format!(

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -719,7 +719,7 @@ impl Epoch {
 
     #[cfg(feature = "std")]
     #[must_use]
-    /// The standard ISO format of this epoch (six digits of subseconds), refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options
+    /// The standard ISO format of this epoch (six digits of subseconds) in the _current_ time scale, refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options.
     pub fn to_isoformat(&self) -> String {
         use crate::efmt::consts::ISO8601_STD;
         use crate::efmt::Formatter;

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2063,3 +2063,42 @@ fn regression_test_gh_282() {
         )
     );
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn regression_test_gh_288() {
+    use core::str::FromStr;
+    let epoch = Epoch::from_str("2021-03-06 11:14:40.9960 GPST").unwrap();
+
+    assert_eq!(
+        "2021-03-06T11:14:40.996000000 GPST",
+        format!("{}", epoch.to_gregorian_str(TimeScale::GPST))
+    );
+    assert_eq!("2021-03-06T11:14:40.996000000 GPST", format!("{epoch}"));
+    assert_eq!(
+        "2021-03-06T11:14:40.996000",
+        format!("{}", epoch.to_isoformat())
+    );
+    assert_eq!(
+        "2021-03-06T11:14:22.996000000 UTC",
+        format!("{}", epoch.to_gregorian_str(TimeScale::UTC))
+    );
+    assert_eq!("2021-03-06T11:14:22.996000000 UTC", format!("{:?}", epoch));
+
+    let epoch = Epoch::from_str("2021-03-06 11:14:40.9960 UTC").unwrap();
+    assert_eq!(
+        "2021-03-06T11:14:58.996000000 GPST",
+        format!("{}", epoch.to_gregorian_str(TimeScale::GPST))
+    );
+    assert_eq!("2021-03-06T11:14:40.996000000 UTC", format!("{:?}", epoch));
+    assert_eq!(
+        "2021-03-06T11:14:40.996000000 UTC",
+        format!("{}", epoch.to_gregorian_str(TimeScale::UTC))
+    );
+    assert_eq!("2021-03-06T11:14:40.996000000 UTC", format!("{epoch}"));
+
+    assert_eq!(
+        "2021-03-06T11:14:40.996000",
+        format!("{}", epoch.to_isoformat())
+    );
+}


### PR DESCRIPTION
Prior to this PR, there was no conversion of the time scale in `to_gregorian_str`, but it should have happened. The Gregorian printing was fixed in #303 .

Closes #288