### PR TITLE
Revert "Update pyo3 requirement from 0.21.1 to 0.22.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hifitime"
 [dependencies]
 serde = { version = "1.0.155", optional = true }
 serde_derive = { version = "1.0.155", optional = true }
-pyo3 = { version = "0.22.0", features = [
+pyo3 = { version = "0.21.1", features = [
     "extension-module",
     "multiple-pymethods",
 ], optional = true }


### PR DESCRIPTION
Reverts nyx-space/hifitime#309

This is required prior to the release of anise 0.4 and Nyx 2 beta. Nyx requires pyo3 log and other stuff that have yet to be updated. 