### PR TITLE
Add autogenerated Bolero harnesses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tabled = { version = "0.15.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 web-time = { version = "1.0.0", optional = true }
 snafu = { version = "0.8.2", default-features = false }
+bolero = "0.11.1"
 
 [features]
 default = ["std"]

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -28,6 +28,8 @@ use core::str::FromStr;
 #[cfg(not(kani))]
 pub mod parse;
 
+use bolero::generator::bolero_generator;
+
 #[cfg(feature = "python")]
 mod python;
 
@@ -63,7 +65,7 @@ pub mod ops;
 /// That difference is exactly 1 nanoseconds, where the former duration is "closer to zero" than the latter.
 /// As such, the largest negative duration that can be represented sets the centuries to i16::MAX and its nanoseconds to NANOSECONDS_PER_CENTURY.
 /// 2. It was also decided that opposite durations are equal, e.g. -15 minutes == 15 minutes. If the direction of time matters, use the signum function.
-#[derive(Clone, Copy, Debug, PartialOrd, Eq, Ord)]
+#[derive(bolero_generator::TypeGenerator, Clone, Copy, Debug, PartialOrd, Eq, Ord)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "hifitime"))]
@@ -826,5 +828,287 @@ mod ut_duration {
         assert_eq!(milliseconds, 0);
         assert_eq!(microseconds, 0);
         assert_eq!(nanoseconds, 0);
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_duration_from_parts() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(centuries, nanoseconds): (i16, u64)| {
+                Some(Duration::from_parts(centuries, nanoseconds))
+            });
+    }
+
+    #[test]
+    fn bolero_test_duration_from_total_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanos): (i128)| Some(Duration::from_total_nanoseconds(nanos)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_truncated_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanos): (i64)| Some(Duration::from_truncated_nanoseconds(nanos)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_days(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_hours() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_hours(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_seconds(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_milliseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_milliseconds(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_microseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_microseconds(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_from_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(value): (f64)| Some(Duration::from_nanoseconds(value)));
+    }
+
+    #[test]
+    fn bolero_test_duration_compose() {
+        bolero::check!().with_type().cloned().for_each(
+            |(sign, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds): (
+                i8,
+                u64,
+                u64,
+                u64,
+                u64,
+                u64,
+                u64,
+                u64,
+            )| {
+                Some(Duration::compose(
+                    sign,
+                    days,
+                    hours,
+                    minutes,
+                    seconds,
+                    milliseconds,
+                    microseconds,
+                    nanoseconds,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_duration_compose_f64() {
+        bolero::check!().with_type().cloned().for_each(
+            |(sign, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds): (
+                i8,
+                f64,
+                f64,
+                f64,
+                f64,
+                f64,
+                f64,
+                f64,
+            )| {
+                Some(Duration::compose_f64(
+                    sign,
+                    days,
+                    hours,
+                    minutes,
+                    seconds,
+                    milliseconds,
+                    microseconds,
+                    nanoseconds,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_duration_from_tz_offset() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(sign, hours, minutes): (i8, i64, i64)| {
+                Some(Duration::from_tz_offset(sign, hours, minutes))
+            });
+    }
+
+    #[test]
+    fn bolero_test_normalize() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(mut callee,): (Duration,)| Some(callee.normalize().clone()));
+    }
+
+    #[test]
+    fn bolero_test_to_parts() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.to_parts().clone()));
+    }
+
+    #[test]
+    fn bolero_test_total_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.total_nanoseconds().clone()));
+    }
+
+    #[test]
+    /*     fn bolero_test_try_truncated_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.try_truncated_nanoseconds().clone()));
+    } */
+    #[test]
+    fn bolero_test_truncated_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.truncated_nanoseconds().clone()));
+    }
+
+    #[test]
+    fn bolero_test_to_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.to_seconds().clone()));
+    }
+
+    #[test]
+    fn bolero_test_to_unit() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, unit): (Duration, Unit)| Some(callee.to_unit(unit).clone()));
+    }
+
+    #[test]
+    fn bolero_test_abs() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.abs().clone()));
+    }
+
+    #[test]
+    fn bolero_test_signum() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.signum().clone()));
+    }
+
+    #[test]
+    fn bolero_test_decompose() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.decompose().clone()));
+    }
+
+    #[test]
+    fn bolero_test_subdivision() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, unit): (Duration, Unit)| Some(callee.subdivision(unit).clone()));
+    }
+
+    #[test]
+    fn bolero_test_floor() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, duration): (Duration, Duration)| Some(callee.floor(duration).clone()),
+        );
+    }
+
+    #[test]
+    fn bolero_test_ceil() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, duration): (Duration, Duration)| Some(callee.ceil(duration).clone()),
+        );
+    }
+
+    #[test]
+    fn bolero_test_round() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, duration): (Duration, Duration)| Some(callee.round(duration).clone()),
+        );
+    }
+
+    #[test]
+    fn bolero_test_approx() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.approx().clone()));
+    }
+
+    #[test]
+    fn bolero_test_min() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Duration, Duration)| Some(callee.min(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_max() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Duration, Duration)| Some(callee.max(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_is_negative() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Duration,)| Some(callee.is_negative().clone()));
     }
 }

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -849,7 +849,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanos): (i128)| Some(Duration::from_total_nanoseconds(nanos)));
+            .for_each(|nanos: i128| Some(Duration::from_total_nanoseconds(nanos)));
     }
 
     #[test]
@@ -857,7 +857,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanos): (i64)| Some(Duration::from_truncated_nanoseconds(nanos)));
+            .for_each(|nanos: i64| Some(Duration::from_truncated_nanoseconds(nanos)));
     }
 
     #[test]
@@ -865,7 +865,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_days(value)));
+            .for_each(|value: f64| Some(Duration::from_days(value)));
     }
 
     #[test]
@@ -873,7 +873,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_hours(value)));
+            .for_each(|value: f64| Some(Duration::from_hours(value)));
     }
 
     #[test]
@@ -881,7 +881,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_seconds(value)));
+            .for_each(|value: f64| Some(Duration::from_seconds(value)));
     }
 
     #[test]
@@ -889,7 +889,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_milliseconds(value)));
+            .for_each(|value: f64| Some(Duration::from_milliseconds(value)));
     }
 
     #[test]
@@ -897,7 +897,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_microseconds(value)));
+            .for_each(|value: f64| Some(Duration::from_microseconds(value)));
     }
 
     #[test]
@@ -905,7 +905,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(value): (f64)| Some(Duration::from_nanoseconds(value)));
+            .for_each(|value: f64| Some(Duration::from_nanoseconds(value)));
     }
 
     #[test]
@@ -996,8 +996,9 @@ mod bolero_harnesses {
             .for_each(|(callee,): (Duration,)| Some(callee.total_nanoseconds().clone()));
     }
 
+    /*
     #[test]
-    /*     fn bolero_test_try_truncated_nanoseconds() {
+    fn bolero_test_try_truncated_nanoseconds() {
         bolero::check!()
             .with_type()
             .cloned()

--- a/src/efmt/formatter.rs
+++ b/src/efmt/formatter.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use bolero::generator::bolero_generator;
 use core::fmt;
 
 use crate::{parser::Token, Duration, Epoch, TimeScale};
@@ -18,7 +19,7 @@ use super::format::Format;
 #[allow(unused_imports)] // Import is indeed used.
 use num_traits::Float;
 
-#[derive(Copy, Clone, Default, Debug, PartialEq)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Default, Debug, PartialEq)]
 pub(crate) struct Item {
     pub(crate) token: Token,
     pub(crate) sep_char: Option<char>,
@@ -301,4 +302,58 @@ impl fmt::Display for Formatter {
         }
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_item_new() {
+        bolero::check!().with_type().cloned().for_each(
+            |(token, sep_char, second_sep_char): (Token, Option<char>, Option<char>)| {
+                Some(Item::new(token, sep_char, second_sep_char))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_sep_char_is() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, c_in): (Item, char)| Some(callee.sep_char_is(c_in).clone()));
+    }
+
+    #[test]
+    fn bolero_test_sep_char_is_not() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, c_in): (Item, char)| Some(callee.sep_char_is_not(c_in).clone()));
+    }
+
+    #[test]
+    fn bolero_test_second_sep_char_is() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, c_in): (Item, char)| Some(callee.second_sep_char_is(c_in).clone()));
+    }
+
+    #[test]
+    fn bolero_test_second_sep_char_is_not() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, c_in): (Item, char)| {
+                Some(callee.second_sep_char_is_not(c_in).clone())
+            });
+    }
+
+    /*     #[test]
+    fn bolero_test_set_timezone() {
+        bolero::check!().with_type().cloned().for_each(
+            |(mut callee, offset): (Formatter, Duration)| Some(callee.set_timezone(offset).clone()),
+        );
+    } */
 }

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -15,6 +15,7 @@ use crate::{
     HIFITIME_REF_YEAR, NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND,
     NANOSECONDS_PER_SECOND_U32,
 };
+use bolero::generator::bolero_generator;
 use core::str::FromStr;
 
 use super::div_rem_f64;
@@ -793,5 +794,271 @@ mod ut_gregorian {
         for year in leap_years.iter() {
             assert!(is_leap_year(*year));
         }
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_epoch_compute_gregorian() {
+        bolero::check!().with_type().cloned().for_each(
+            |(duration, time_scale): (Duration, TimeScale)| {
+                Some(Epoch::compute_gregorian(duration, time_scale))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_to_gregorian_str() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, time_scale): (Epoch, TimeScale)| {
+                Some(callee.to_gregorian_str(time_scale).clone())
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_to_gregorian_utc() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.to_gregorian_utc().clone()));
+    }
+
+    #[test]
+    fn bolero_test_to_gregorian_tai() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.to_gregorian_tai().clone()));
+    }
+
+    #[test]
+    fn bolero_test_epoch_maybe_from_gregorian_tai() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos): (i32, u8, u8, u8, u8, u8, u32)| {
+                Some(Epoch::maybe_from_gregorian_tai(
+                    year, month, day, hour, minute, second, nanos,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_maybe_from_gregorian() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos, time_scale): (
+                i32,
+                u8,
+                u8,
+                u8,
+                u8,
+                u8,
+                u32,
+                TimeScale,
+            )| {
+                Some(Epoch::maybe_from_gregorian(
+                    year, month, day, hour, minute, second, nanos, time_scale,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_tai() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos): (i32, u8, u8, u8, u8, u8, u32)| {
+                Some(Epoch::from_gregorian_tai(
+                    year, month, day, hour, minute, second, nanos,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_tai_at_midnight() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year, month, day): (i32, u8, u8)| {
+                Some(Epoch::from_gregorian_tai_at_midnight(year, month, day))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_tai_at_noon() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year, month, day): (i32, u8, u8)| {
+                Some(Epoch::from_gregorian_tai_at_noon(year, month, day))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_tai_hms() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second): (i32, u8, u8, u8, u8, u8)| {
+                Some(Epoch::from_gregorian_tai_hms(
+                    year, month, day, hour, minute, second,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_maybe_from_gregorian_utc() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos): (i32, u8, u8, u8, u8, u8, u32)| {
+                Some(Epoch::maybe_from_gregorian_utc(
+                    year, month, day, hour, minute, second, nanos,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_utc() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos): (i32, u8, u8, u8, u8, u8, u32)| {
+                Some(Epoch::from_gregorian_utc(
+                    year, month, day, hour, minute, second, nanos,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_utc_at_midnight() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year, month, day): (i32, u8, u8)| {
+                Some(Epoch::from_gregorian_utc_at_midnight(year, month, day))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_utc_at_noon() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year, month, day): (i32, u8, u8)| {
+                Some(Epoch::from_gregorian_utc_at_noon(year, month, day))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_utc_hms() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second): (i32, u8, u8, u8, u8, u8)| {
+                Some(Epoch::from_gregorian_utc_hms(
+                    year, month, day, hour, minute, second,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos, time_scale): (
+                i32,
+                u8,
+                u8,
+                u8,
+                u8,
+                u8,
+                u32,
+                TimeScale,
+            )| {
+                Some(Epoch::from_gregorian(
+                    year, month, day, hour, minute, second, nanos, time_scale,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_at_midnight() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, time_scale): (i32, u8, u8, TimeScale)| {
+                Some(Epoch::from_gregorian_at_midnight(
+                    year, month, day, time_scale,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_at_noon() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, time_scale): (i32, u8, u8, TimeScale)| {
+                Some(Epoch::from_gregorian_at_noon(year, month, day, time_scale))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gregorian_hms() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, time_scale): (
+                i32,
+                u8,
+                u8,
+                u8,
+                u8,
+                u8,
+                TimeScale,
+            )| {
+                Some(Epoch::from_gregorian_hms(
+                    year, month, day, hour, minute, second, time_scale,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_is_gregorian_valid() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, month, day, hour, minute, second, nanos): (i32, u8, u8, u8, u8, u8, u32)| {
+                Some(is_gregorian_valid(
+                    year, month, day, hour, minute, second, nanos,
+                ))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_january_years() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year): (i32)| Some(january_years(year)));
+    }
+
+    #[test]
+    fn bolero_test_july_years() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year): (i32)| Some(july_years(year)));
+    }
+
+    #[test]
+    fn bolero_test_usual_days_per_month() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(month): (u8)| Some(usual_days_per_month(month)));
+    }
+
+    #[test]
+    fn bolero_test_is_leap_year() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(year): (i32)| Some(is_leap_year(year)));
     }
 }

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -15,7 +15,6 @@ use crate::{
     HIFITIME_REF_YEAR, NANOSECONDS_PER_MICROSECOND, NANOSECONDS_PER_MILLISECOND,
     NANOSECONDS_PER_SECOND_U32,
 };
-use bolero::generator::bolero_generator;
 use core::str::FromStr;
 
 use super::div_rem_f64;
@@ -1035,7 +1034,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(year): (i32)| Some(january_years(year)));
+            .for_each(|year: i32| Some(january_years(year)));
     }
 
     #[test]
@@ -1043,7 +1042,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(year): (i32)| Some(july_years(year)));
+            .for_each(|year: i32| Some(july_years(year)));
     }
 
     #[test]
@@ -1051,7 +1050,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(month): (u8)| Some(usual_days_per_month(month)));
+            .for_each(|month: u8| Some(usual_days_per_month(month)));
     }
 
     #[test]
@@ -1059,6 +1058,6 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(year): (i32)| Some(is_leap_year(year)));
+            .for_each(|year: i32| Some(is_leap_year(year)));
     }
 }

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -1443,7 +1443,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_tai_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_tai_duration(duration)));
     }
 
     /*     #[test]
@@ -1488,7 +1488,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_tai_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_tai_seconds(seconds)));
     }
 
     #[test]
@@ -1496,7 +1496,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_tai_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_tai_days(days)));
     }
 
     #[test]
@@ -1504,7 +1504,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_utc_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_utc_duration(duration)));
     }
 
     #[test]
@@ -1512,7 +1512,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_utc_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_utc_seconds(seconds)));
     }
 
     #[test]
@@ -1520,7 +1520,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_utc_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_utc_days(days)));
     }
 
     #[test]
@@ -1528,7 +1528,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_gpst_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_gpst_duration(duration)));
     }
 
     #[test]
@@ -1536,7 +1536,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_qzsst_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_qzsst_duration(duration)));
     }
 
     #[test]
@@ -1544,7 +1544,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_gst_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_gst_duration(duration)));
     }
 
     #[test]
@@ -1552,7 +1552,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_bdt_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_bdt_duration(duration)));
     }
 
     #[test]
@@ -1560,7 +1560,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_tai(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_tai(days)));
     }
 
     #[test]
@@ -1578,7 +1578,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_utc(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_utc(days)));
     }
 
     #[test]
@@ -1586,7 +1586,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_gpst(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_gpst(days)));
     }
 
     #[test]
@@ -1594,7 +1594,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_qzsst(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_qzsst(days)));
     }
 
     #[test]
@@ -1602,7 +1602,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_gst(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_gst(days)));
     }
 
     #[test]
@@ -1610,7 +1610,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_mjd_bdt(days)));
+            .for_each(|days: f64| Some(Epoch::from_mjd_bdt(days)));
     }
 
     #[test]
@@ -1618,7 +1618,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_tai(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_tai(days)));
     }
 
     #[test]
@@ -1636,7 +1636,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_utc(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_utc(days)));
     }
 
     #[test]
@@ -1644,7 +1644,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_gpst(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_gpst(days)));
     }
 
     #[test]
@@ -1652,7 +1652,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_qzsst(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_qzsst(days)));
     }
 
     #[test]
@@ -1660,7 +1660,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_gst(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_gst(days)));
     }
 
     #[test]
@@ -1668,7 +1668,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_bdt(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_bdt(days)));
     }
 
     #[test]
@@ -1676,7 +1676,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_tt_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_tt_seconds(seconds)));
     }
 
     #[test]
@@ -1684,7 +1684,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_tt_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_tt_duration(duration)));
     }
 
     #[test]
@@ -1692,9 +1692,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds_since_j2000): (f64)| {
-                Some(Epoch::from_et_seconds(seconds_since_j2000))
-            });
+            .for_each(|seconds_since_j2000: f64| Some(Epoch::from_et_seconds(seconds_since_j2000)));
     }
 
     #[test]
@@ -1702,7 +1700,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration_since_j2000): (Duration)| {
+            .for_each(|duration_since_j2000: Duration| {
                 Some(Epoch::from_et_duration(duration_since_j2000))
             });
     }
@@ -1712,7 +1710,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds_j2000): (f64)| Some(Epoch::from_tdb_seconds(seconds_j2000)));
+            .for_each(|seconds_j2000: f64| Some(Epoch::from_tdb_seconds(seconds_j2000)));
     }
 
     #[test]
@@ -1720,7 +1718,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration_since_j2000): (Duration)| {
+            .for_each(|duration_since_j2000: Duration| {
                 Some(Epoch::from_tdb_duration(duration_since_j2000))
             });
     }
@@ -1730,7 +1728,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_et(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_et(days)));
     }
 
     #[test]
@@ -1738,7 +1736,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_jde_tdb(days)));
+            .for_each(|days: f64| Some(Epoch::from_jde_tdb(days)));
     }
 
     #[test]
@@ -1746,7 +1744,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_gpst_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_gpst_seconds(seconds)));
     }
 
     #[test]
@@ -1754,7 +1752,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_gpst_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_gpst_days(days)));
     }
 
     #[test]
@@ -1762,7 +1760,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_gpst_nanoseconds(nanoseconds)));
+            .for_each(|nanoseconds: u64| Some(Epoch::from_gpst_nanoseconds(nanoseconds)));
     }
 
     #[test]
@@ -1770,7 +1768,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_qzsst_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_qzsst_seconds(seconds)));
     }
 
     #[test]
@@ -1778,7 +1776,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_qzsst_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_qzsst_days(days)));
     }
 
     #[test]
@@ -1786,7 +1784,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_qzsst_nanoseconds(nanoseconds)));
+            .for_each(|nanoseconds: u64| Some(Epoch::from_qzsst_nanoseconds(nanoseconds)));
     }
 
     #[test]
@@ -1794,7 +1792,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_gst_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_gst_seconds(seconds)));
     }
 
     #[test]
@@ -1802,7 +1800,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_gst_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_gst_days(days)));
     }
 
     #[test]
@@ -1810,7 +1808,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_gst_nanoseconds(nanoseconds)));
+            .for_each(|nanoseconds: u64| Some(Epoch::from_gst_nanoseconds(nanoseconds)));
     }
 
     #[test]
@@ -1818,7 +1816,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_bdt_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_bdt_seconds(seconds)));
     }
 
     #[test]
@@ -1826,7 +1824,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(days): (f64)| Some(Epoch::from_bdt_days(days)));
+            .for_each(|days: f64| Some(Epoch::from_bdt_days(days)));
     }
 
     #[test]
@@ -1834,7 +1832,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_bdt_nanoseconds(nanoseconds)));
+            .for_each(|nanoseconds: u64| Some(Epoch::from_bdt_nanoseconds(nanoseconds)));
     }
 
     #[test]
@@ -1842,7 +1840,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(duration): (Duration)| Some(Epoch::from_unix_duration(duration)));
+            .for_each(|duration: Duration| Some(Epoch::from_unix_duration(duration)));
     }
 
     #[test]
@@ -1850,7 +1848,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::from_unix_seconds(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::from_unix_seconds(seconds)));
     }
 
     #[test]
@@ -1858,7 +1856,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(millisecond): (f64)| Some(Epoch::from_unix_milliseconds(millisecond)));
+            .for_each(|millisecond: f64| Some(Epoch::from_unix_milliseconds(millisecond)));
     }
 
     #[test]
@@ -1866,7 +1864,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::delta_et_tai(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::delta_et_tai(seconds)));
     }
 
     #[test]
@@ -1874,7 +1872,7 @@ mod bolero_harnesses {
         bolero::check!()
             .with_type()
             .cloned()
-            .for_each(|(seconds): (f64)| Some(Epoch::inner_g(seconds)));
+            .for_each(|seconds: f64| Some(Epoch::inner_g(seconds)));
     }
 
     #[test]

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     HifitimeError, MonthName, TimeScale, TimeUnits, BDT_REF_EPOCH, ET_EPOCH_S, GPST_REF_EPOCH,
     GST_REF_EPOCH, MJD_J1900, MJD_OFFSET, NANOSECONDS_PER_DAY, QZSST_REF_EPOCH, UNIX_REF_EPOCH,
 };
+use bolero::generator::bolero_generator;
 use core::cmp::Eq;
 use core::str::FromStr;
 pub use gregorian::is_gregorian_valid;
@@ -75,7 +76,7 @@ pub const NAIF_K: f64 = 1.657e-3;
 /// Defines a nanosecond-precision Epoch.
 ///
 /// Refer to the appropriate functions for initializing this Epoch from different time scales or representations.
-#[derive(Copy, Clone, Default, Eq)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Default, Eq)]
 #[repr(C)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "hifitime"))]
@@ -1423,5 +1424,508 @@ mod ut_epoch {
         assert_eq!(content, serde_json::to_string(&e).unwrap());
         let parsed: Epoch = serde_json::from_str(content).unwrap();
         assert_eq!(e, parsed);
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_to_time_scale() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, ts): (Epoch, TimeScale)| Some(callee.to_time_scale(ts).clone()));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tai_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_tai_duration(duration)));
+    }
+
+    /*     #[test]
+    fn bolero_test_leap_seconds_with() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, iers_only, provider): (Epoch, bool, u16)| {
+                Some(callee.leap_seconds_with(iers_only, provider).clone())
+            },
+        );
+    } */
+
+    #[test]
+    fn bolero_test_epoch_from_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration, ts): (Duration, TimeScale)| {
+                Some(Epoch::from_duration(duration, ts))
+            });
+    }
+
+    #[test]
+    fn bolero_test_to_duration_since_j1900() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.to_duration_since_j1900().clone()));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tai_parts() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(centuries, nanoseconds): (i16, u64)| {
+                Some(Epoch::from_tai_parts(centuries, nanoseconds))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tai_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_tai_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tai_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_tai_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_utc_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_utc_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_utc_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_utc_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_utc_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_utc_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gpst_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_gpst_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_qzsst_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_qzsst_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gst_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_gst_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_bdt_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_bdt_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_tai() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_tai(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_in_time_scale() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days, time_scale): (f64, TimeScale)| {
+                Some(Epoch::from_mjd_in_time_scale(days, time_scale))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_utc() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_utc(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_gpst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_gpst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_qzsst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_qzsst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_gst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_gst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_mjd_bdt() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_mjd_bdt(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_tai() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_tai(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_in_time_scale() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days, time_scale): (f64, TimeScale)| {
+                Some(Epoch::from_jde_in_time_scale(days, time_scale))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_utc() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_utc(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_gpst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_gpst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_qzsst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_qzsst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_gst() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_gst(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_bdt() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_bdt(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tt_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_tt_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tt_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_tt_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_et_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds_since_j2000): (f64)| {
+                Some(Epoch::from_et_seconds(seconds_since_j2000))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_et_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration_since_j2000): (Duration)| {
+                Some(Epoch::from_et_duration(duration_since_j2000))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tdb_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds_j2000): (f64)| Some(Epoch::from_tdb_seconds(seconds_j2000)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_tdb_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration_since_j2000): (Duration)| {
+                Some(Epoch::from_tdb_duration(duration_since_j2000))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_et() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_et(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_jde_tdb() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_jde_tdb(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gpst_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_gpst_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gpst_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_gpst_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gpst_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_gpst_nanoseconds(nanoseconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_qzsst_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_qzsst_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_qzsst_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_qzsst_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_qzsst_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_qzsst_nanoseconds(nanoseconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gst_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_gst_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gst_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_gst_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_gst_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_gst_nanoseconds(nanoseconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_bdt_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_bdt_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_bdt_days() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(days): (f64)| Some(Epoch::from_bdt_days(days)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_bdt_nanoseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(nanoseconds): (u64)| Some(Epoch::from_bdt_nanoseconds(nanoseconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_unix_duration() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(duration): (Duration)| Some(Epoch::from_unix_duration(duration)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_unix_seconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::from_unix_seconds(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_unix_milliseconds() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(millisecond): (f64)| Some(Epoch::from_unix_milliseconds(millisecond)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_delta_et_tai() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::delta_et_tai(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_inner_g() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seconds): (f64)| Some(Epoch::inner_g(seconds)));
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_time_of_week() {
+        bolero::check!().with_type().cloned().for_each(
+            |(week, nanoseconds, time_scale): (u32, u64, TimeScale)| {
+                Some(Epoch::from_time_of_week(week, nanoseconds, time_scale))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_time_of_week_utc() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(week, nanoseconds): (u32, u64)| {
+                Some(Epoch::from_time_of_week_utc(week, nanoseconds))
+            });
+    }
+
+    #[test]
+    fn bolero_test_epoch_from_day_of_year() {
+        bolero::check!().with_type().cloned().for_each(
+            |(year, days, time_scale): (i32, f64, TimeScale)| {
+                Some(Epoch::from_day_of_year(year, days, time_scale))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_div_rem_f64() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(me, rhs): (f64, f64)| Some(div_rem_f64(me, rhs)));
+    }
+
+    #[test]
+    fn bolero_test_div_euclid_f64() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(lhs, rhs): (f64, f64)| Some(div_euclid_f64(lhs, rhs)));
+    }
+
+    #[test]
+    fn bolero_test_rem_euclid_f64() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(lhs, rhs): (f64, f64)| Some(rem_euclid_f64(lhs, rhs)));
     }
 }

--- a/src/epoch/ops.rs
+++ b/src/epoch/ops.rs
@@ -8,7 +8,6 @@
  * Documentation: https://nyxspace.com/
  */
 
-use bolero::generator::bolero_generator;
 use core::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use core::hash::{Hash, Hasher};
 use core::ops::{Add, AddAssign, Sub, SubAssign};

--- a/src/epoch/ops.rs
+++ b/src/epoch/ops.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use bolero::generator::bolero_generator;
 use core::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use core::hash::{Hash, Hasher};
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -376,5 +377,138 @@ impl Hash for Epoch {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.duration.hash(state);
         self.time_scale.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_min() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Epoch, Epoch)| Some(callee.min(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_max() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Epoch, Epoch)| Some(callee.max(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_floor() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, duration): (Epoch, Duration)| Some(callee.floor(duration).clone()));
+    }
+
+    #[test]
+    fn bolero_test_ceil() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, duration): (Epoch, Duration)| Some(callee.ceil(duration).clone()));
+    }
+
+    #[test]
+    fn bolero_test_round() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, duration): (Epoch, Duration)| Some(callee.round(duration).clone()));
+    }
+
+    #[test]
+    fn bolero_test_to_time_of_week() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.to_time_of_week().clone()));
+    }
+
+    #[test]
+    fn bolero_test_weekday_in_time_scale() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, time_scale): (Epoch, TimeScale)| {
+                Some(callee.weekday_in_time_scale(time_scale).clone())
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_weekday() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.weekday().clone()));
+    }
+
+    #[test]
+    fn bolero_test_weekday_utc() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Epoch,)| Some(callee.weekday_utc().clone()));
+    }
+
+    #[test]
+    fn bolero_test_next() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| Some(callee.next(weekday).clone()));
+    }
+
+    #[test]
+    fn bolero_test_next_weekday_at_midnight() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| {
+                Some(callee.next_weekday_at_midnight(weekday).clone())
+            });
+    }
+
+    #[test]
+    fn bolero_test_next_weekday_at_noon() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| {
+                Some(callee.next_weekday_at_noon(weekday).clone())
+            });
+    }
+
+    #[test]
+    fn bolero_test_previous() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| Some(callee.previous(weekday).clone()));
+    }
+
+    #[test]
+    fn bolero_test_previous_weekday_at_midnight() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| {
+                Some(callee.previous_weekday_at_midnight(weekday).clone())
+            });
+    }
+
+    #[test]
+    fn bolero_test_previous_weekday_at_noon() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, weekday): (Epoch, Weekday)| {
+                Some(callee.previous_weekday_at_noon(weekday).clone())
+            });
     }
 }

--- a/src/epoch/system_time.rs
+++ b/src/epoch/system_time.rs
@@ -34,3 +34,23 @@ impl Epoch {
         Ok(Self::from_unix_duration(duration))
     }
 }
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_duration_since_unix_epoch() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(): ()| Some(duration_since_unix_epoch()));
+    }
+
+    #[test]
+    fn bolero_test_epoch_now() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(): ()| Some(Epoch::now()));
+    }
+}

--- a/src/epoch/ut1.rs
+++ b/src/epoch/ut1.rs
@@ -21,6 +21,8 @@ use std::{fs::File, io::Read};
 use core::fmt;
 use core::ops::Index;
 
+use bolero::generator::bolero_generator;
+
 use crate::{Duration, Epoch, HifitimeError, ParsingError, TimeScale, Unit};
 
 impl Epoch {
@@ -64,7 +66,7 @@ impl Epoch {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, Tabled)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Debug, Default, Tabled)]
 pub struct DeltaTaiUt1 {
     pub epoch: Epoch,
     pub delta_tai_minus_ut1: Duration,

--- a/src/epoch/with_funcs.rs
+++ b/src/epoch/with_funcs.rs
@@ -9,7 +9,6 @@
  */
 
 use crate::{Duration, Epoch};
-use bolero::generator::bolero_generator;
 
 impl Epoch {
     /// Returns a copy of self where the time is set to the provided hours, minutes, seconds

--- a/src/epoch/with_funcs.rs
+++ b/src/epoch/with_funcs.rs
@@ -9,6 +9,7 @@
  */
 
 use crate::{Duration, Epoch};
+use bolero::generator::bolero_generator;
 
 impl Epoch {
     /// Returns a copy of self where the time is set to the provided hours, minutes, seconds
@@ -146,5 +147,53 @@ impl Epoch {
             ),
             self.time_scale,
         )
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_with_hms() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, hours, minutes, seconds): (Epoch, u64, u64, u64)| {
+                Some(callee.with_hms(hours, minutes, seconds).clone())
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_with_hms_from() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Epoch, Epoch)| Some(callee.with_hms_from(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_with_time_from() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Epoch, Epoch)| Some(callee.with_time_from(other).clone()));
+    }
+
+    #[test]
+    fn bolero_test_with_hms_strict() {
+        bolero::check!().with_type().cloned().for_each(
+            |(callee, hours, minutes, seconds): (Epoch, u64, u64, u64)| {
+                Some(callee.with_hms_strict(hours, minutes, seconds).clone())
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_with_hms_strict_from() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, other): (Epoch, Epoch)| {
+                Some(callee.with_hms_strict_from(other).clone())
+            });
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use bolero::generator::bolero_generator;
 use core::num::ParseIntError;
 use snafu::prelude::*;
 
@@ -41,7 +42,7 @@ pub enum HifitimeError {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Snafu, PartialEq)]
+#[derive(bolero_generator::TypeGenerator, Debug, Snafu, PartialEq)]
 pub enum DurationError {
     Overflow,
     Underflow,

--- a/src/month.rs
+++ b/src/month.rs
@@ -9,6 +9,7 @@
  */
 
 use crate::ParsingError;
+use bolero::generator::bolero_generator;
 use core::fmt;
 use core::str::FromStr;
 
@@ -18,7 +19,7 @@ use pyo3::prelude::*;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,8 +9,9 @@
  */
 
 use crate::{HifitimeError, ParsingError};
+use bolero::generator::bolero_generator;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(bolero_generator::TypeGenerator, Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Token {
     Year,
     YearShort,
@@ -275,5 +276,42 @@ impl Token {
                 | Token::MonthName
                 | Token::MonthNameShort
         )
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    /*     #[test]
+    fn bolero_test_value_ok() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee, val): (Token, i32)| Some(callee.value_ok(val).clone()));
+    } */
+
+    #[test]
+    fn bolero_test_gregorian_position() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Token,)| Some(callee.gregorian_position().clone()));
+    }
+
+    /*     #[test]
+    fn bolero_test_advance_with() {
+        bolero::check!().with_type().cloned().for_each(
+            |(mut callee, ending_char): (Token, char)| {
+                Some(callee.advance_with(ending_char).clone())
+            },
+        );
+    } */
+
+    #[test]
+    fn bolero_test_is_numeric() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Token,)| Some(callee.is_numeric().clone()));
     }
 }

--- a/src/timescale/mod.rs
+++ b/src/timescale/mod.rs
@@ -19,6 +19,8 @@ mod kani;
 
 mod fmt;
 
+use bolero::generator::bolero_generator;
+
 use crate::{Duration, Epoch, Unit, SECONDS_PER_DAY};
 
 /// The J1900 reference epoch (1900-01-01 at noon) TAI.
@@ -81,7 +83,9 @@ pub(crate) const HIFITIME_REF_YEAR: i32 = 1900;
 
 /// Enum of the different time systems available
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    bolero_generator::TypeGenerator, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TimeScale {
@@ -260,5 +264,49 @@ mod unit_test_timescale {
             format!("{}", TimeScale::ET.reference_epoch()),
             "2000-01-01T12:00:00 ET"
         );
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_formatted_len() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (TimeScale,)| Some(callee.formatted_len().clone()));
+    }
+
+    #[test]
+    fn bolero_test_is_gnss() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (TimeScale,)| Some(callee.is_gnss().clone()));
+    }
+
+    #[test]
+    fn bolero_test_reference_epoch() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (TimeScale,)| Some(callee.reference_epoch().clone()));
+    }
+
+    #[test]
+    fn bolero_test_prime_epoch_offset() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (TimeScale,)| Some(callee.prime_epoch_offset().clone()));
+    }
+
+    #[test]
+    fn bolero_test_gregorian_epoch_offset() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (TimeScale,)| Some(callee.gregorian_epoch_offset().clone()));
     }
 }

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -10,6 +10,7 @@
 
 use super::{Duration, Epoch};
 
+use bolero::generator::bolero_generator;
 use core::fmt;
 
 #[cfg(not(feature = "std"))]
@@ -26,7 +27,7 @@ NOTE: This is taken from itertools: https://docs.rs/itertools-num/0.1.3/src/iter
 */
 
 /// An iterator of a sequence of evenly spaced Epochs.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(bolero_generator::TypeGenerator, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "hifitime"))]
 pub struct TimeSeries {
@@ -413,5 +414,27 @@ mod tests {
 
         assert_eq!(cnt, 5); // Five because the first item is always inclusive
         assert_eq!(cur_epoch, start, "incorrect last item in iterator");
+    }
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_timeseries_exclusive() {
+        bolero::check!().with_type().cloned().for_each(
+            |(start, end, step): (Epoch, Epoch, Duration)| {
+                Some(TimeSeries::exclusive(start, end, step))
+            },
+        );
+    }
+
+    #[test]
+    fn bolero_test_timeseries_inclusive() {
+        bolero::check!().with_type().cloned().for_each(
+            |(start, end, step): (Epoch, Epoch, Duration)| {
+                Some(TimeSeries::inclusive(start, end, step))
+            },
+        );
     }
 }

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -8,6 +8,7 @@
  * Documentation: https://nyxspace.com/
  */
 
+use bolero::generator::bolero_generator;
 use core::ops::{Add, Mul, Sub};
 
 #[cfg(not(feature = "std"))]
@@ -25,7 +26,7 @@ use crate::{
 };
 
 /// An Enum to perform time unit conversions.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum Unit {
     Nanosecond,
@@ -41,7 +42,7 @@ pub enum Unit {
 }
 
 /// An Enum to convert frequencies to their approximate duration, **rounded to the closest nanosecond**.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum Freq {
     GigaHertz,

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -9,6 +9,7 @@
  */
 
 use crate::{Duration, ParsingError, Unit};
+use bolero::generator::bolero_generator;
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::str::FromStr;
@@ -19,7 +20,7 @@ use pyo3::prelude::*;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(bolero_generator::TypeGenerator, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -201,4 +202,16 @@ fn test_iso_weekday() {
     assert_eq!(Weekday::Thursday.to_c89_weekday(), 4);
     assert_eq!(Weekday::Friday.to_c89_weekday(), 5);
     assert_eq!(Weekday::Saturday.to_c89_weekday(), 6);
+}
+
+#[cfg(test)]
+mod bolero_harnesses {
+    use super::*;
+    #[test]
+    fn bolero_test_to_c89_weekday() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(callee,): (Weekday,)| Some(callee.to_c89_weekday().clone()));
+    }
 }


### PR DESCRIPTION
[Bolero](https://github.com/camshaft/bolero) is property based testing tool. Bolero also supports fuzzing engines like AFL and libfuzzer. Additionally, Bolero can produce [Kani proofs](https://camshaft.github.io/bolero/features/unified-interface.html?highlight=kani#kani).

I was thinking that these Bolero harnesses may provide a smoother path toward formal verification.

These harnesses were autogenerated. 