### PR TITLE
Introduce doc_cfg and mark ut1 within ut1 crate feature

### DIFF
--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -22,6 +22,7 @@ mod system_time;
 mod kani_verif;
 
 #[cfg(feature = "ut1")]
+#[cfg_attr(docrs, doc(cfg(feature = "ut1")))]
 pub mod ut1;
 
 pub mod leap_seconds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 /*
  * Hifitime, part of the Nyx Space tools


### PR DESCRIPTION
The doc cfg macro emphasizes in the documentation how to unlock feature dependent structures

![image](https://github.com/user-attachments/assets/4b4dce69-56fe-4515-b524-5a4241673c5a)
