### PR TITLE
Fix ceil with zero duration

### DIFF
--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -539,7 +539,11 @@ impl Duration {
     /// ```
     pub fn floor(&self, duration: Self) -> Self {
         Self::from_total_nanoseconds(
-            self.total_nanoseconds() - self.total_nanoseconds() % duration.total_nanoseconds(),
+            if duration.total_nanoseconds() == 0 {
+                0
+            } else {
+                self.total_nanoseconds() - self.total_nanoseconds() % duration.total_nanoseconds()
+            }
         )
     }
 

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -538,13 +538,11 @@ impl Duration {
     /// assert_eq!(two_hours_three_min.floor(1.hours() + 5.minutes()), 1.hours() + 5.minutes());
     /// ```
     pub fn floor(&self, duration: Self) -> Self {
-        Self::from_total_nanoseconds(
-            if duration.total_nanoseconds() == 0 {
-                0
-            } else {
-                self.total_nanoseconds() - self.total_nanoseconds() % duration.total_nanoseconds()
-            }
-        )
+        Self::from_total_nanoseconds(if duration.total_nanoseconds() == 0 {
+            0
+        } else {
+            self.total_nanoseconds() - self.total_nanoseconds() % duration.total_nanoseconds()
+        })
     }
 
     /// Ceils this duration to the closest provided duration

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -582,15 +582,11 @@ fn test_min_max() {
 fn regression_test_gh_244() {
     use hifitime::Epoch;
 
-    let _local0 = if let Ok(x) = Epoch::maybe_from_gregorian_utc(1792, 1, 1, 0, 0, 0, 0) {
-        x
-    } else {
-        std::process::exit(0);
-    };
-    let _local5 = Epoch::duration_in_year(&_local0);
-    let _ = Epoch::to_utc_seconds(&_local0);
-    let _ = Duration::decompose(&_local5);
-    let calculated_epoch = Epoch::ceil(&_local0, _local5);
+    let local0 = Epoch::maybe_from_gregorian_utc(1792, 1, 1, 0, 0, 0, 0).unwrap();
+    let local5 = Epoch::duration_in_year(&local0);
+    let _ = Epoch::to_utc_seconds(&local0);
+    let _ = Duration::decompose(&local5);
+    let calculated_epoch = Epoch::ceil(&local0, local5);
     
     let expected_epoch = Epoch::maybe_from_gregorian_utc(1900, 1, 1, 0, 0, 0, 0).unwrap();
     assert_eq!(calculated_epoch, expected_epoch);

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -580,13 +580,12 @@ fn test_min_max() {
 
 #[test]
 fn regression_test_gh_244() {
-    use hifitime::Epoch;
-
-    let local0 = Epoch::maybe_from_gregorian_utc(1792, 1, 1, 0, 0, 0, 0).unwrap();
-    let local5 = Epoch::duration_in_year(&local0);
-    let _ = Epoch::to_utc_seconds(&local0);
-    let _ = Duration::decompose(&local5);
-    let calculated_epoch = Epoch::ceil(&local0, local5);
-    let expected_epoch = Epoch::maybe_from_gregorian_utc(1900, 1, 1, 0, 0, 0, 0).unwrap();
-    assert_eq!(calculated_epoch, expected_epoch);
+    let zero = Duration::ZERO;
+    // Test that the ceil of a zero duration is still zero.
+    assert_eq!(zero.ceil(zero), zero);
+    let non_zero = Duration::from_parts(1, 23456);
+    // Test that the ceil of a non-zero duration by zero is still that original duration.
+    assert_eq!(non_zero.ceil(zero), non_zero);
+    // Test that the ceil of a zero duration by a non-zero is still zero.
+    assert_eq!(zero.ceil(non_zero), zero);
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -584,8 +584,8 @@ fn regression_test_gh_244() {
     // Test that the ceil of a zero duration is still zero.
     assert_eq!(zero.ceil(zero), zero);
     let non_zero = Duration::from_parts(1, 23456);
-    // Test that the ceil of a non-zero duration by zero is still that original duration.
-    assert_eq!(non_zero.ceil(zero), non_zero);
-    // Test that the ceil of a zero duration by a non-zero is still zero.
-    assert_eq!(zero.ceil(non_zero), zero);
+    // Test that the ceil of a non-zero duration by zero is still zero.
+    assert_eq!(non_zero.ceil(zero), zero);
+    // Test that the ceil of a zero duration by a non-zero is non-zero duration.
+    assert_eq!(zero.ceil(non_zero), non_zero);
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -587,7 +587,6 @@ fn regression_test_gh_244() {
     let _ = Epoch::to_utc_seconds(&local0);
     let _ = Duration::decompose(&local5);
     let calculated_epoch = Epoch::ceil(&local0, local5);
-    
     let expected_epoch = Epoch::maybe_from_gregorian_utc(1900, 1, 1, 0, 0, 0, 0).unwrap();
     assert_eq!(calculated_epoch, expected_epoch);
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -577,3 +577,21 @@ fn test_min_max() {
     assert_eq!(d1, d1.max(d0));
     assert_eq!(d1, d0.max(d1));
 }
+
+#[test]
+fn regression_test_gh_244() {
+    use hifitime::Epoch;
+
+    let _local0 = if let Ok(x) = Epoch::maybe_from_gregorian_utc(1792, 1, 1, 0, 0, 0, 0) {
+        x
+    } else {
+        std::process::exit(0);
+    };
+    let _local5 = Epoch::duration_in_year(&_local0);
+    let _ = Epoch::to_utc_seconds(&_local0);
+    let _ = Duration::decompose(&_local5);
+    let calculated_epoch = Epoch::ceil(&_local0, _local5);
+    
+    let expected_epoch = Epoch::maybe_from_gregorian_utc(1900, 1, 1, 0, 0, 0, 0).unwrap();
+    assert_eq!(calculated_epoch, expected_epoch);
+}


### PR DESCRIPTION
Fix 14. Arithmetic overflow bug in #244  

In #244 , `ceil()` is called with a duration of 0, which can lead to an arithmetic overflow. While returning 0 is one way to address this, another approach is to report an error to the user. 

I'm not very familiar with operations involving time, so apologies for any misunderstandings.