### PR TITLE
MJD/JDE UTC fix + `to_time_scale` now available in Python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ web-sys = { version = "0.3", features = [
     'PerformanceTiming',
 ] }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [[bench]]
 name = "crit_epoch"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifitime"
-version = "4.0.0-alpha.1"
+version = "4.0.0-beta"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/"

--- a/examples/python/basic.py
+++ b/examples/python/basic.py
@@ -1,6 +1,6 @@
 """
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/examples/python/timescales.py
+++ b/examples/python/timescales.py
@@ -1,6 +1,6 @@
 """
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/kani_verif.rs
+++ b/src/duration/kani_verif.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/ops.rs
+++ b/src/duration/ops.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/parse.rs
+++ b/src/duration/parse.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/python.rs
+++ b/src/duration/python.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/duration/std.rs
+++ b/src/duration/std.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/efmt/consts.rs
+++ b/src/efmt/consts.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/efmt/formatter.rs
+++ b/src/efmt/formatter.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/efmt/mod.rs
+++ b/src/efmt/mod.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/formatting.rs
+++ b/src/epoch/formatting.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/initializers.rs
+++ b/src/epoch/initializers.rs
@@ -102,21 +102,18 @@ impl Epoch {
 
     #[must_use]
     pub fn from_mjd_tai(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::TAI)
+    }
+
+    pub fn from_mjd_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
         assert!(
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self::from_tai_duration((days - MJD_J1900) * Unit::Day)
-    }
-
-    pub fn from_mjd_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
-        // always refer to TAI/mjd
-        let mut e = Self::from_mjd_tai(days);
-        if time_scale.uses_leap_seconds() {
-            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
+        Self {
+            duration: (days - MJD_J1900) * Unit::Day,
+            time_scale,
         }
-        e.time_scale = time_scale;
-        e
     }
 
     #[must_use]
@@ -142,21 +139,18 @@ impl Epoch {
 
     #[must_use]
     pub fn from_jde_tai(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::TAI)
+    }
+
+    fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
         assert!(
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"
         );
-        Self::from_tai_duration((days - MJD_J1900 - MJD_OFFSET) * Unit::Day)
-    }
-
-    fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
-        // always refer to TAI/jde
-        let mut e = Self::from_jde_tai(days);
-        if time_scale.uses_leap_seconds() {
-            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
+        Self {
+            duration: (days - MJD_J1900 - MJD_OFFSET) * Unit::Day,
+            time_scale,
         }
-        e.time_scale = time_scale;
-        e
     }
 
     #[must_use]

--- a/src/epoch/initializers.rs
+++ b/src/epoch/initializers.rs
@@ -142,7 +142,7 @@ impl Epoch {
         Self::from_jde_in_time_scale(days, TimeScale::TAI)
     }
 
-    fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
+    pub fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
         assert!(
             days.is_finite(),
             "Attempted to initialize Epoch with non finite number"

--- a/src/epoch/initializers.rs
+++ b/src/epoch/initializers.rs
@@ -1,0 +1,415 @@
+/*
+ * Hifitime, part of the Nyx Space tools
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * This Source Code Form is subject to the terms of the Apache
+ * v. 2.0. If a copy of the Apache License was not distributed with this
+ * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Documentation: https://nyxspace.com/
+ */
+
+use core::str::FromStr;
+
+use snafu::ResultExt;
+
+use crate::{
+    efmt::Format, errors::ParseSnafu, Duration, Epoch, HifitimeError, TimeScale, Unit, Weekday,
+    ET_OFFSET_US, MJD_J1900, MJD_OFFSET, NANOSECONDS_PER_DAY, UNIX_REF_EPOCH,
+};
+
+// Defines the methods that should be classmethods in Python, but must be redefined as per https://github.com/PyO3/pyo3/issues/1003#issuecomment-844433346
+impl Epoch {
+    #[must_use]
+    /// Creates a new Epoch from a Duration as the time difference between this epoch and TAI reference epoch.
+    pub const fn from_tai_duration(duration: Duration) -> Self {
+        Self {
+            duration,
+            time_scale: TimeScale::TAI,
+        }
+    }
+
+    pub fn to_duration_since_j1900(&self) -> Duration {
+        self.to_time_scale(TimeScale::TAI).duration
+    }
+
+    #[must_use]
+    /// Creates a new Epoch from its centuries and nanosecond since the TAI reference epoch.
+    pub fn from_tai_parts(centuries: i16, nanoseconds: u64) -> Self {
+        Self::from_tai_duration(Duration::from_parts(centuries, nanoseconds))
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided TAI seconds since 1900 January 01 at midnight
+    pub fn from_tai_seconds(seconds: f64) -> Self {
+        assert!(
+            seconds.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tai_duration(seconds * Unit::Second)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided TAI days since 1900 January 01 at midnight
+    pub fn from_tai_days(days: f64) -> Self {
+        assert!(
+            days.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tai_duration(days * Unit::Day)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
+    pub fn from_utc_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::UTC)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
+    pub fn from_utc_seconds(seconds: f64) -> Self {
+        Self::from_utc_duration(seconds * Unit::Second)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided UTC days since 1900 January 01 at midnight
+    pub fn from_utc_days(days: f64) -> Self {
+        Self::from_utc_duration(days * Unit::Day)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
+    pub fn from_gpst_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::GPST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
+    pub fn from_qzsst_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since August 21st 1999 midnight
+    pub fn from_gst_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::GST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since January 1st midnight
+    pub fn from_bdt_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::BDT)
+    }
+
+    #[must_use]
+    pub fn from_mjd_tai(days: f64) -> Self {
+        assert!(
+            days.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tai_duration((days - MJD_J1900) * Unit::Day)
+    }
+
+    pub fn from_mjd_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
+        // always refer to TAI/mjd
+        let mut e = Self::from_mjd_tai(days);
+        if time_scale.uses_leap_seconds() {
+            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
+        }
+        e.time_scale = time_scale;
+        e
+    }
+
+    #[must_use]
+    pub fn from_mjd_utc(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::UTC)
+    }
+    #[must_use]
+    pub fn from_mjd_gpst(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::GPST)
+    }
+    #[must_use]
+    pub fn from_mjd_qzsst(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::QZSST)
+    }
+    #[must_use]
+    pub fn from_mjd_gst(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::GST)
+    }
+    #[must_use]
+    pub fn from_mjd_bdt(days: f64) -> Self {
+        Self::from_mjd_in_time_scale(days, TimeScale::BDT)
+    }
+
+    #[must_use]
+    pub fn from_jde_tai(days: f64) -> Self {
+        assert!(
+            days.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tai_duration((days - MJD_J1900 - MJD_OFFSET) * Unit::Day)
+    }
+
+    fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
+        // always refer to TAI/jde
+        let mut e = Self::from_jde_tai(days);
+        if time_scale.uses_leap_seconds() {
+            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
+        }
+        e.time_scale = time_scale;
+        e
+    }
+
+    #[must_use]
+    pub fn from_jde_utc(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::UTC)
+    }
+    #[must_use]
+    pub fn from_jde_gpst(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::GPST)
+    }
+    #[must_use]
+    pub fn from_jde_qzsst(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::QZSST)
+    }
+    #[must_use]
+    pub fn from_jde_gst(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::GST)
+    }
+    #[must_use]
+    pub fn from_jde_bdt(days: f64) -> Self {
+        Self::from_jde_in_time_scale(days, TimeScale::BDT)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
+    pub fn from_tt_seconds(seconds: f64) -> Self {
+        assert!(
+            seconds.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tt_duration(seconds * Unit::Second)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
+    pub fn from_tt_duration(duration: Duration) -> Self {
+        Self::from_duration(duration, TimeScale::TT)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the Ephemeris Time seconds past 2000 JAN 01 (J2000 reference)
+    pub fn from_et_seconds(seconds_since_j2000: f64) -> Epoch {
+        Self::from_et_duration(seconds_since_j2000 * Unit::Second)
+    }
+
+    /// Initializes an Epoch from the duration between J2000 and the current epoch as per NAIF SPICE.
+    ///
+    /// # Limitation
+    /// This method uses a Newton Raphson iteration to find the appropriate TAI duration. This method is only accuracy to a few nanoseconds.
+    /// Hence, when calling `as_et_duration()` and re-initializing it with `from_et_duration` you may have a few nanoseconds of difference (expect less than 10 ns).
+    ///
+    /// # Warning
+    /// The et2utc function of NAIF SPICE will assume that there are 9 leap seconds before 01 JAN 1972,
+    /// as this date introduces 10 leap seconds. At the time of writing, this does _not_ seem to be in
+    /// line with IERS and the documentation in the leap seconds list.
+    ///
+    /// In order to match SPICE, the as_et_duration() function will manually get rid of that difference.
+    #[must_use]
+    pub fn from_et_duration(duration_since_j2000: Duration) -> Self {
+        Self::from_duration(duration_since_j2000, TimeScale::ET)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from Dynamic Barycentric Time (TDB) seconds past 2000 JAN 01 midnight (difference than SPICE)
+    /// NOTE: This uses the ESA algorithm, which is a notch more complicated than the SPICE algorithm, but more precise.
+    /// In fact, SPICE algorithm is precise +/- 30 microseconds for a century whereas ESA algorithm should be exactly correct.
+    pub fn from_tdb_seconds(seconds_j2000: f64) -> Epoch {
+        assert!(
+            seconds_j2000.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_tdb_duration(seconds_j2000 * Unit::Second)
+    }
+
+    #[must_use]
+    /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) whose epoch is 2000 JAN 01 noon TAI.
+    pub fn from_tdb_duration(duration_since_j2000: Duration) -> Epoch {
+        Self::from_duration(duration_since_j2000, TimeScale::TDB)
+    }
+
+    #[must_use]
+    /// Initialize from the JDE days
+    pub fn from_jde_et(days: f64) -> Self {
+        assert!(
+            days.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_jde_tdb(days)
+    }
+
+    #[must_use]
+    /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) in JD days
+    pub fn from_jde_tdb(days: f64) -> Self {
+        assert!(
+            days.is_finite(),
+            "Attempted to initialize Epoch with non finite number"
+        );
+        Self::from_jde_tai(days) - Unit::Microsecond * ET_OFFSET_US
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of seconds since the GPS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_gpst_seconds(seconds: f64) -> Self {
+        Self::from_duration(seconds * Unit::Second, TimeScale::GPST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of days since the GPS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_gpst_days(days: f64) -> Self {
+        Self::from_duration(days * Unit::Day, TimeScale::GPST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// This may be useful for time keeping devices that use GPS as a time source.
+    pub fn from_gpst_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::GPST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of seconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_qzsst_seconds(seconds: f64) -> Self {
+        Self::from_duration(seconds * Unit::Second, TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of days since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    pub fn from_qzsst_days(days: f64) -> Self {
+        Self::from_duration(days * Unit::Day, TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of nanoseconds since the QZSS Time Epoch,
+    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
+    /// This may be useful for time keeping devices that use QZSS as a time source.
+    pub fn from_qzsst_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::QZSST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of seconds since the GST Time Epoch,
+    /// starting August 21st 1999 midnight (UTC)
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    pub fn from_gst_seconds(seconds: f64) -> Self {
+        Self::from_duration(seconds * Unit::Second, TimeScale::GST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of days since the GST Time Epoch,
+    /// starting August 21st 1999 midnight (UTC)
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
+    pub fn from_gst_days(days: f64) -> Self {
+        Self::from_duration(days * Unit::Day, TimeScale::GST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
+    /// starting August 21st 1999 midnight (UTC)
+    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
+    pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::GST)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of seconds since the BDT Time Epoch,
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
+    pub fn from_bdt_seconds(seconds: f64) -> Self {
+        Self::from_duration(seconds * Unit::Second, TimeScale::BDT)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of days since the BDT Time Epoch,
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
+    pub fn from_bdt_days(days: f64) -> Self {
+        Self::from_duration(days * Unit::Day, TimeScale::BDT)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the number of nanoseconds since the BDT Time Epoch,
+    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
+    /// This may be useful for time keeping devices that use BDT as a time source.
+    pub fn from_bdt_nanoseconds(nanoseconds: u64) -> Self {
+        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::BDT)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided duration since UTC midnight 1970 January 01.
+    pub fn from_unix_duration(duration: Duration) -> Self {
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + duration)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided UNIX second timestamp since UTC midnight 1970 January 01.
+    pub fn from_unix_seconds(seconds: f64) -> Self {
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + seconds * Unit::Second)
+    }
+
+    #[must_use]
+    /// Initialize an Epoch from the provided UNIX millisecond timestamp since UTC midnight 1970 January 01.
+    pub fn from_unix_milliseconds(millisecond: f64) -> Self {
+        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + millisecond * Unit::Millisecond)
+    }
+
+    /// Initializes an Epoch from the provided Format.
+    pub fn from_str_with_format(s_in: &str, format: Format) -> Result<Self, HifitimeError> {
+        format.parse(s_in)
+    }
+
+    /// Initializes an Epoch from the Format as a string.
+    pub fn from_format_str(s_in: &str, format_str: &str) -> Result<Self, HifitimeError> {
+        Format::from_str(format_str)
+            .with_context(|_| ParseSnafu {
+                details: "when using format string",
+            })?
+            .parse(s_in)
+    }
+
+    /// Builds an Epoch from given `week`: elapsed weeks counter into the desired Time scale, and the amount of nanoseconds within that week.
+    /// For example, this is how GPS vehicles describe a GPST epoch.
+    ///
+    /// Note that this constructor relies on 128 bit integer math and may be slow on embedded devices.
+    #[must_use]
+    pub fn from_time_of_week(week: u32, nanoseconds: u64, time_scale: TimeScale) -> Self {
+        let mut nanos = i128::from(nanoseconds);
+        nanos += i128::from(week) * Weekday::DAYS_PER_WEEK_I128 * i128::from(NANOSECONDS_PER_DAY);
+        let duration = Duration::from_total_nanoseconds(nanos);
+        Self::from_duration(duration, time_scale)
+    }
+
+    #[must_use]
+    /// Builds a UTC Epoch from given `week`: elapsed weeks counter and "ns" amount of nanoseconds since closest Sunday Midnight.
+    pub fn from_time_of_week_utc(week: u32, nanoseconds: u64) -> Self {
+        Self::from_time_of_week(week, nanoseconds, TimeScale::UTC)
+    }
+
+    #[must_use]
+    /// Builds an Epoch from the provided year, days in the year, and a time scale.
+    ///
+    /// # Limitations
+    /// In the TDB or ET time scales, there may be an error of up to 750 nanoseconds when initializing an Epoch this way.
+    /// This is because we first initialize the epoch in Gregorian scale and then apply the TDB/ET offset, but that offset actually depends on the precise time.
+    ///
+    /// # Day couting behavior
+    ///
+    /// The day counter starts at 01, in other words, 01 January is day 1 of the counter, as per the GPS specificiations.
+    ///
+    pub fn from_day_of_year(year: i32, days: f64, time_scale: TimeScale) -> Self {
+        let start_of_year = Self::from_gregorian(year, 1, 1, 0, 0, 0, 0, time_scale);
+        start_of_year + (days - 1.0) * Unit::Day
+    }
+}

--- a/src/epoch/kani_verif.rs
+++ b/src/epoch/kani_verif.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/kani_verif.rs
+++ b/src/epoch/kani_verif.rs
@@ -8,9 +8,9 @@
  * Documentation: https://nyxspace.com/
  */
 
-use super::{Duration, Epoch, TimeScale, Unit, Weekday, TT_OFFSET_MS};
 use crate::epoch::system_time::duration_since_unix_epoch;
 use crate::leap_seconds::LeapSecond;
+use crate::{Duration, Epoch, TimeScale, Unit, Weekday, TT_OFFSET_MS};
 
 #[kani::proof]
 fn formal_epoch_reciprocity_tai() {

--- a/src/epoch/leap_seconds.rs
+++ b/src/epoch/leap_seconds.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/leap_seconds_file.rs
+++ b/src/epoch/leap_seconds_file.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.
@@ -10,6 +10,7 @@
 
 mod formatting;
 mod gregorian;
+pub mod initializers;
 mod ops;
 mod with_funcs;
 
@@ -28,13 +29,11 @@ pub mod ut1;
 pub mod leap_seconds;
 
 use crate::duration::{Duration, Unit};
-use crate::efmt::format::Format;
 use crate::errors::{DurationError, ParseSnafu};
 use crate::leap_seconds::{LatestLeapSeconds, LeapSecondProvider};
-use crate::Weekday;
 use crate::{
     HifitimeError, MonthName, TimeScale, TimeUnits, BDT_REF_EPOCH, ET_EPOCH_S, GPST_REF_EPOCH,
-    GST_REF_EPOCH, MJD_J1900, MJD_OFFSET, NANOSECONDS_PER_DAY, QZSST_REF_EPOCH, UNIX_REF_EPOCH,
+    GST_REF_EPOCH, MJD_J1900, MJD_OFFSET, QZSST_REF_EPOCH, UNIX_REF_EPOCH,
 };
 use core::cmp::Eq;
 use core::str::FromStr;
@@ -238,15 +237,6 @@ impl Epoch {
         }
     }
 
-    #[must_use]
-    /// Creates a new Epoch from a Duration as the time difference between this epoch and TAI reference epoch.
-    pub const fn from_tai_duration(duration: Duration) -> Self {
-        Self {
-            duration,
-            time_scale: TimeScale::TAI,
-        }
-    }
-
     /// Get the accumulated number of leap seconds up to this Epoch from the provided LeapSecondProvider.
     /// Returns None if the epoch is before 1960, year at which UTC was defined.
     ///
@@ -279,357 +269,6 @@ impl Epoch {
         }
     }
 
-    pub fn to_duration_since_j1900(&self) -> Duration {
-        self.to_time_scale(TimeScale::TAI).duration
-    }
-
-    #[must_use]
-    /// Creates a new Epoch from its centuries and nanosecond since the TAI reference epoch.
-    pub fn from_tai_parts(centuries: i16, nanoseconds: u64) -> Self {
-        Self::from_tai_duration(Duration::from_parts(centuries, nanoseconds))
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided TAI seconds since 1900 January 01 at midnight
-    pub fn from_tai_seconds(seconds: f64) -> Self {
-        assert!(
-            seconds.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tai_duration(seconds * Unit::Second)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided TAI days since 1900 January 01 at midnight
-    pub fn from_tai_days(days: f64) -> Self {
-        assert!(
-            days.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tai_duration(days * Unit::Day)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
-    pub fn from_utc_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::UTC)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided UTC seconds since 1900 January 01 at midnight
-    pub fn from_utc_seconds(seconds: f64) -> Self {
-        Self::from_utc_duration(seconds * Unit::Second)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided UTC days since 1900 January 01 at midnight
-    pub fn from_utc_days(days: f64) -> Self {
-        Self::from_utc_duration(days * Unit::Day)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
-    pub fn from_gpst_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::GPST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided duration since 1980 January 6 at midnight
-    pub fn from_qzsst_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::QZSST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided duration since August 21st 1999 midnight
-    pub fn from_gst_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::GST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided duration since January 1st midnight
-    pub fn from_bdt_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::BDT)
-    }
-
-    #[must_use]
-    pub fn from_mjd_tai(days: f64) -> Self {
-        assert!(
-            days.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tai_duration((days - MJD_J1900) * Unit::Day)
-    }
-
-    fn from_mjd_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
-        // always refer to TAI/mjd
-        let mut e = Self::from_mjd_tai(days);
-        if time_scale.uses_leap_seconds() {
-            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
-        }
-        e.time_scale = time_scale;
-        e
-    }
-
-    #[must_use]
-    pub fn from_mjd_utc(days: f64) -> Self {
-        Self::from_mjd_in_time_scale(days, TimeScale::UTC)
-    }
-    #[must_use]
-    pub fn from_mjd_gpst(days: f64) -> Self {
-        Self::from_mjd_in_time_scale(days, TimeScale::GPST)
-    }
-    #[must_use]
-    pub fn from_mjd_qzsst(days: f64) -> Self {
-        Self::from_mjd_in_time_scale(days, TimeScale::QZSST)
-    }
-    #[must_use]
-    pub fn from_mjd_gst(days: f64) -> Self {
-        Self::from_mjd_in_time_scale(days, TimeScale::GST)
-    }
-    #[must_use]
-    pub fn from_mjd_bdt(days: f64) -> Self {
-        Self::from_mjd_in_time_scale(days, TimeScale::BDT)
-    }
-
-    #[must_use]
-    pub fn from_jde_tai(days: f64) -> Self {
-        assert!(
-            days.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tai_duration((days - MJD_J1900 - MJD_OFFSET) * Unit::Day)
-    }
-
-    fn from_jde_in_time_scale(days: f64, time_scale: TimeScale) -> Self {
-        // always refer to TAI/jde
-        let mut e = Self::from_jde_tai(days);
-        if time_scale.uses_leap_seconds() {
-            e.duration += e.leap_seconds(true).unwrap_or(0.0) * Unit::Second;
-        }
-        e.time_scale = time_scale;
-        e
-    }
-
-    #[must_use]
-    pub fn from_jde_utc(days: f64) -> Self {
-        Self::from_jde_in_time_scale(days, TimeScale::UTC)
-    }
-    #[must_use]
-    pub fn from_jde_gpst(days: f64) -> Self {
-        Self::from_jde_in_time_scale(days, TimeScale::GPST)
-    }
-    #[must_use]
-    pub fn from_jde_qzsst(days: f64) -> Self {
-        Self::from_jde_in_time_scale(days, TimeScale::QZSST)
-    }
-    #[must_use]
-    pub fn from_jde_gst(days: f64) -> Self {
-        Self::from_jde_in_time_scale(days, TimeScale::GST)
-    }
-    #[must_use]
-    pub fn from_jde_bdt(days: f64) -> Self {
-        Self::from_jde_in_time_scale(days, TimeScale::BDT)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
-    pub fn from_tt_seconds(seconds: f64) -> Self {
-        assert!(
-            seconds.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tt_duration(seconds * Unit::Second)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided TT seconds (approximated to 32.184s delta from TAI)
-    pub fn from_tt_duration(duration: Duration) -> Self {
-        Self::from_duration(duration, TimeScale::TT)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the Ephemeris Time seconds past 2000 JAN 01 (J2000 reference)
-    pub fn from_et_seconds(seconds_since_j2000: f64) -> Epoch {
-        Self::from_et_duration(seconds_since_j2000 * Unit::Second)
-    }
-
-    /// Initializes an Epoch from the duration between J2000 and the current epoch as per NAIF SPICE.
-    ///
-    /// # Limitation
-    /// This method uses a Newton Raphson iteration to find the appropriate TAI duration. This method is only accuracy to a few nanoseconds.
-    /// Hence, when calling `as_et_duration()` and re-initializing it with `from_et_duration` you may have a few nanoseconds of difference (expect less than 10 ns).
-    ///
-    /// # Warning
-    /// The et2utc function of NAIF SPICE will assume that there are 9 leap seconds before 01 JAN 1972,
-    /// as this date introduces 10 leap seconds. At the time of writing, this does _not_ seem to be in
-    /// line with IERS and the documentation in the leap seconds list.
-    ///
-    /// In order to match SPICE, the as_et_duration() function will manually get rid of that difference.
-    #[must_use]
-    pub fn from_et_duration(duration_since_j2000: Duration) -> Self {
-        Self::from_duration(duration_since_j2000, TimeScale::ET)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from Dynamic Barycentric Time (TDB) seconds past 2000 JAN 01 midnight (difference than SPICE)
-    /// NOTE: This uses the ESA algorithm, which is a notch more complicated than the SPICE algorithm, but more precise.
-    /// In fact, SPICE algorithm is precise +/- 30 microseconds for a century whereas ESA algorithm should be exactly correct.
-    pub fn from_tdb_seconds(seconds_j2000: f64) -> Epoch {
-        assert!(
-            seconds_j2000.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_tdb_duration(seconds_j2000 * Unit::Second)
-    }
-
-    #[must_use]
-    /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) whose epoch is 2000 JAN 01 noon TAI.
-    pub fn from_tdb_duration(duration_since_j2000: Duration) -> Epoch {
-        Self::from_duration(duration_since_j2000, TimeScale::TDB)
-    }
-
-    #[must_use]
-    /// Initialize from the JDE days
-    pub fn from_jde_et(days: f64) -> Self {
-        assert!(
-            days.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_jde_tdb(days)
-    }
-
-    #[must_use]
-    /// Initialize from Dynamic Barycentric Time (TDB) (same as SPICE ephemeris time) in JD days
-    pub fn from_jde_tdb(days: f64) -> Self {
-        assert!(
-            days.is_finite(),
-            "Attempted to initialize Epoch with non finite number"
-        );
-        Self::from_jde_tai(days) - Unit::Microsecond * ET_OFFSET_US
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of seconds since the GPS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn from_gpst_seconds(seconds: f64) -> Self {
-        Self::from_duration(seconds * Unit::Second, TimeScale::GPST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of days since the GPS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn from_gpst_days(days: f64) -> Self {
-        Self::from_duration(days * Unit::Day, TimeScale::GPST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    /// This may be useful for time keeping devices that use GPS as a time source.
-    pub fn from_gpst_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::GPST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of seconds since the QZSS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn from_qzsst_seconds(seconds: f64) -> Self {
-        Self::from_duration(seconds * Unit::Second, TimeScale::QZSST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of days since the QZSS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    pub fn from_qzsst_days(days: f64) -> Self {
-        Self::from_duration(days * Unit::Day, TimeScale::QZSST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of nanoseconds since the QZSS Time Epoch,
-    /// defined as UTC midnight of January 5th to 6th 1980 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>).
-    /// This may be useful for time keeping devices that use QZSS as a time source.
-    pub fn from_qzsst_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::QZSST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of seconds since the GST Time Epoch,
-    /// starting August 21st 1999 midnight (UTC)
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
-    pub fn from_gst_seconds(seconds: f64) -> Self {
-        Self::from_duration(seconds * Unit::Second, TimeScale::GST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of days since the GST Time Epoch,
-    /// starting August 21st 1999 midnight (UTC)
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-    pub fn from_gst_days(days: f64) -> Self {
-        Self::from_duration(days * Unit::Day, TimeScale::GST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of nanoseconds since the GPS Time Epoch,
-    /// starting August 21st 1999 midnight (UTC)
-    /// (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-    pub fn from_gst_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::GST)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of seconds since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-    pub fn from_bdt_seconds(seconds: f64) -> Self {
-        Self::from_duration(seconds * Unit::Second, TimeScale::BDT)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of days since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>)
-    pub fn from_bdt_days(days: f64) -> Self {
-        Self::from_duration(days * Unit::Day, TimeScale::BDT)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the number of nanoseconds since the BDT Time Epoch,
-    /// starting on January 1st 2006 (cf. <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS>).
-    /// This may be useful for time keeping devices that use BDT as a time source.
-    pub fn from_bdt_nanoseconds(nanoseconds: u64) -> Self {
-        Self::from_duration(Duration::from_parts(0, nanoseconds), TimeScale::BDT)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided duration since UTC midnight 1970 January 01.
-    pub fn from_unix_duration(duration: Duration) -> Self {
-        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + duration)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided UNIX second timestamp since UTC midnight 1970 January 01.
-    pub fn from_unix_seconds(seconds: f64) -> Self {
-        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + seconds * Unit::Second)
-    }
-
-    #[must_use]
-    /// Initialize an Epoch from the provided UNIX millisecond timestamp since UTC midnight 1970 January 01.
-    pub fn from_unix_milliseconds(millisecond: f64) -> Self {
-        Self::from_utc_duration(UNIX_REF_EPOCH.to_utc_duration() + millisecond * Unit::Millisecond)
-    }
-
-    /// Initializes an Epoch from the provided Format.
-    pub fn from_str_with_format(s_in: &str, format: Format) -> Result<Self, HifitimeError> {
-        format.parse(s_in)
-    }
-
-    /// Initializes an Epoch from the Format as a string.
-    pub fn from_format_str(s_in: &str, format_str: &str) -> Result<Self, HifitimeError> {
-        Format::from_str(format_str)
-            .with_context(|_| ParseSnafu {
-                details: "when using format string",
-            })?
-            .parse(s_in)
-    }
-
     fn delta_et_tai(seconds: f64) -> f64 {
         // Calculate M, the mean anomaly.4
         let m = NAIF_M0 + seconds * NAIF_M1;
@@ -644,40 +283,6 @@ impl Epoch {
         let g = TAU / 360.0 * 357.528 + 1.990_910_018_065_731e-7 * seconds;
         // Return gamma
         1.658e-3 * (g + 1.67e-2 * g.sin()).sin()
-    }
-
-    /// Builds an Epoch from given `week`: elapsed weeks counter into the desired Time scale, and the amount of nanoseconds within that week.
-    /// For example, this is how GPS vehicles describe a GPST epoch.
-    ///
-    /// Note that this constructor relies on 128 bit integer math and may be slow on embedded devices.
-    #[must_use]
-    pub fn from_time_of_week(week: u32, nanoseconds: u64, time_scale: TimeScale) -> Self {
-        let mut nanos = i128::from(nanoseconds);
-        nanos += i128::from(week) * Weekday::DAYS_PER_WEEK_I128 * i128::from(NANOSECONDS_PER_DAY);
-        let duration = Duration::from_total_nanoseconds(nanos);
-        Self::from_duration(duration, time_scale)
-    }
-
-    #[must_use]
-    /// Builds a UTC Epoch from given `week`: elapsed weeks counter and "ns" amount of nanoseconds since closest Sunday Midnight.
-    pub fn from_time_of_week_utc(week: u32, nanoseconds: u64) -> Self {
-        Self::from_time_of_week(week, nanoseconds, TimeScale::UTC)
-    }
-
-    #[must_use]
-    /// Builds an Epoch from the provided year, days in the year, and a time scale.
-    ///
-    /// # Limitations
-    /// In the TDB or ET time scales, there may be an error of up to 750 nanoseconds when initializing an Epoch this way.
-    /// This is because we first initialize the epoch in Gregorian scale and then apply the TDB/ET offset, but that offset actually depends on the precise time.
-    ///
-    /// # Day couting behavior
-    ///
-    /// The day counter starts at 01, in other words, 01 January is day 1 of the counter, as per the GPS specificiations.
-    ///
-    pub fn from_day_of_year(year: i32, days: f64, time_scale: TimeScale) -> Self {
-        let start_of_year = Self::from_gregorian(year, 1, 1, 0, 0, 0, 0, time_scale);
-        start_of_year + (days - 1.0) * Unit::Day
     }
 }
 

--- a/src/epoch/ops.rs
+++ b/src/epoch/ops.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/python.rs
+++ b/src/epoch/python.rs
@@ -1,6 +1,6 @@
 /*
 * Hifitime, part of the Nyx Space tools
-* Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+* Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
 * This Source Code Form is subject to the terms of the Apache
 * v. 2.0. If a copy of the Apache License was not distributed with this
 * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/system_time.rs
+++ b/src/epoch/system_time.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/system_time.rs
+++ b/src/epoch/system_time.rs
@@ -15,7 +15,8 @@ use crate::{Duration, Epoch, HifitimeError};
 /// Clippy thinks these are the same type, but they aren't.
 #[allow(clippy::unnecessary_fallible_conversions)]
 pub(crate) fn duration_since_unix_epoch() -> Result<Duration, HifitimeError> {
-    // TODO: Check why there is a map_err and and_then
+    // map_err maps the duration_since error into a hifitime error, if the conversion to a SystemTime fails.
+    // Then we converts a valid SystemTime into a Hifitime duration, unless it fails via and_then
     web_time::SystemTime::now()
         .duration_since(web_time::SystemTime::UNIX_EPOCH)
         .map_err(|_| HifitimeError::SystemTimeError)

--- a/src/epoch/ut1.rs
+++ b/src/epoch/ut1.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/epoch/with_funcs.rs
+++ b/src/epoch/with_funcs.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/month.rs
+++ b/src/month.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/timescale/fmt.rs
+++ b/src/timescale/fmt.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/timescale/kani.rs
+++ b/src/timescale/kani.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/timescale/mod.rs
+++ b/src/timescale/mod.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -1,6 +1,6 @@
 /*
  * Hifitime, part of the Nyx Space tools
- * Copyright (C) 2023 Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
+ * Copyright (C) 2017-onwards Christopher Rabotin <christopher.rabotin@gmail.com> et al. (cf. https://github.com/nyx-space/hifitime/graphs/contributors)
  * This Source Code Form is subject to the terms of the Apache
  * v. 2.0. If a copy of the Apache License was not distributed with this
  * file, You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.

--- a/tests/efmt.rs
+++ b/tests/efmt.rs
@@ -1,5 +1,3 @@
-use std::f32::consts::E;
-
 use hifitime::efmt::consts::*;
 use hifitime::prelude::*;
 

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2069,9 +2069,15 @@ fn regression_test_gh_282() {
 fn regression_test_gh_288() {
     use core::str::FromStr;
     let epoch = Epoch::from_str("2021-03-06 11:14:40.9960 GPST").unwrap();
+    let epoch_from_gpst =
+        Epoch::from_gregorian(2021, 3, 6, 11, 14, 40, 996_000_000, TimeScale::GPST);
 
     assert_eq!(
         "2021-03-06T11:14:40.996000000 GPST",
+        format!("{}", epoch.to_gregorian_str(TimeScale::GPST))
+    );
+    assert_eq!(
+        format!("{}", epoch_from_gpst.to_gregorian_str(TimeScale::GPST)),
         format!("{}", epoch.to_gregorian_str(TimeScale::GPST))
     );
     assert_eq!("2021-03-06T11:14:40.996000000 GPST", format!("{epoch}"));

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2143,3 +2143,32 @@ fn regression_test_gh_317() {
         nanos
     );
 }
+
+#[test]
+fn regression_test_gh_302() {
+    let days = 60660.0;
+    let mjd = Epoch::from_mjd_utc(days);
+    let extra_duration = 2 * Unit::Hour + 5 * Unit::Minute + 8 * Unit::Second;
+    let mjd_plus_duration = mjd + extra_duration;
+    assert_eq!(
+        mjd_plus_duration.to_mjd_utc_days(),
+        days + extra_duration.to_unit(Unit::Day)
+    );
+    assert_eq!(
+        mjd_plus_duration.to_gregorian_str(TimeScale::UTC),
+        "2024-12-16T02:05:08 UTC"
+    );
+
+    // Repeat with JDE
+    let jde = Epoch::from_jde_utc(days + MJD_OFFSET);
+    let extra_duration = 2 * Unit::Hour + 5 * Unit::Minute + 8 * Unit::Second;
+    let jde_plus_duration = jde + extra_duration;
+    assert_eq!(
+        mjd_plus_duration.to_mjd_utc_days(),
+        days + extra_duration.to_unit(Unit::Day)
+    );
+    assert_eq!(
+        jde_plus_duration.to_gregorian_str(TimeScale::UTC),
+        "2024-12-16T02:05:08 UTC"
+    );
+}

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2144,6 +2144,7 @@ fn regression_test_gh_317() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn regression_test_gh_302() {
     let days = 60660.0;

--- a/tests/python/test_epoch.py
+++ b/tests/python/test_epoch.py
@@ -25,6 +25,9 @@ def test_strtime():
         print(f"caught {e}")
     else:
         raise AssertionError("failed to catch parsing error")
+    
+    epoch_tdb = epoch.to_time_scale(TimeScale.TDB)
+    assert str(epoch_tdb) == "2023-04-13T23:32:26.185636390 TDB"
 
 
 def test_utcnow():


### PR DESCRIPTION
Closes #331 
Closes #257 
Closes #302 

This also makes #229 much easier to get started on. My only hesitation with that ticket is that in Python, we use `init_from_unix_seconds` _a lot_ and we're launching in a few weeks so I'm hesitant to change my habits this close to launch.