### PR TITLE
Implement lossless From methods for Duration conversions

### DIFF
--- a/src/duration/std.rs
+++ b/src/duration/std.rs
@@ -12,25 +12,29 @@
 
 extern crate core;
 
-use super::{Duration, Unit};
+use super::Duration;
 
 impl From<Duration> for std::time::Duration {
     /// Converts a duration into an std::time::Duration
     ///
     /// # Limitations
     /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
-    /// 2. If the duration larger than the MAX duration, this will return std::time::Duration::MAX
+    /// 2. If the duration is larger than the MAX duration, this will return std::time::Duration::MAX
     fn from(hf_duration: Duration) -> Self {
-        const NANOS_PER_SEC: u128 = std::time::Duration::from_secs(1).as_nanos();
-        let nanos = hf_duration.total_nanoseconds();
-        let unsigned_nanos = u128::try_from(nanos).unwrap_or(0);
+        use crate::NANOSECONDS_PER_SECOND;
+        if hf_duration.signum() == -1 {
+            std::time::Duration::ZERO
+        } else {
+            let nanos = hf_duration.total_nanoseconds();
+            let unsigned_nanos = u128::try_from(nanos).unwrap_or(0);
 
-        let secs: u64 = (unsigned_nanos / NANOS_PER_SEC)
-            .try_into()
-            .unwrap_or(u64::MAX);
-        let subsec_nanos = (unsigned_nanos % NANOS_PER_SEC) as u32;
+            let secs: u64 = (unsigned_nanos / NANOSECONDS_PER_SECOND as u128)
+                .try_into()
+                .unwrap_or(u64::MAX);
+            let subsec_nanos = (unsigned_nanos % NANOSECONDS_PER_SECOND as u128) as u32;
 
-        std::time::Duration::new(secs, subsec_nanos)
+            std::time::Duration::new(secs, subsec_nanos)
+        }
     }
 }
 
@@ -39,7 +43,7 @@ impl From<std::time::Duration> for Duration {
     ///
     /// # Limitations
     /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
-    /// 2. If the duration larger than the MAX duration, this will return std::time::Duration::MAX
+    /// 2. If the duration is larger than the MAX duration, this will return std::time::Duration::MAX
     fn from(std_duration: std::time::Duration) -> Self {
         Duration::from_total_nanoseconds(std_duration.as_nanos().try_into().unwrap_or(i128::MAX))
     }

--- a/src/duration/std.rs
+++ b/src/duration/std.rs
@@ -15,11 +15,12 @@ extern crate core;
 use super::Duration;
 
 impl From<Duration> for std::time::Duration {
-    /// Converts a duration into an std::time::Duration
+    /// Converts a Duration into a std::time::Duration
     ///
     /// # Limitations
-    /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
-    /// 2. If the duration is larger than the MAX duration, this will return std::time::Duration::MAX
+    /// 1. If the Duration is negative, this will return a std::time::Duration::ZERO.
+    /// 2. If the Duration is Duration::MAX, this will return
+    ///     the equivalent of std::time::Duration::from_secs(103407943680000)
     fn from(hf_duration: Duration) -> Self {
         use crate::NANOSECONDS_PER_SECOND;
         if hf_duration.signum() == -1 {
@@ -39,11 +40,10 @@ impl From<Duration> for std::time::Duration {
 }
 
 impl From<std::time::Duration> for Duration {
-    /// Converts a duration into an std::time::Duration
+    /// Converts a std::time::Duration into a Duration
     ///
     /// # Limitations
-    /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
-    /// 2. If the duration is larger than the MAX duration, this will return std::time::Duration::MAX
+    /// 1. If the std::time::Duration is larger than Duration::MAX, this will return Duration::MAX
     fn from(std_duration: std::time::Duration) -> Self {
         Duration::from_total_nanoseconds(std_duration.as_nanos().try_into().unwrap_or(i128::MAX))
     }

--- a/src/duration/std.rs
+++ b/src/duration/std.rs
@@ -21,15 +21,16 @@ impl From<Duration> for std::time::Duration {
     /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
     /// 2. If the duration larger than the MAX duration, this will return std::time::Duration::MAX
     fn from(hf_duration: Duration) -> Self {
-        let (sign, days, hours, minutes, seconds, milli, us, nano) = hf_duration.decompose();
-        if sign < 0 {
-            std::time::Duration::ZERO
-        } else {
-            // Build the seconds separately from the nanos.
-            let above_ns_f64: f64 =
-                Duration::compose(sign, days, hours, minutes, seconds, milli, us, 0).to_seconds();
-            std::time::Duration::new(above_ns_f64 as u64, nano as u32)
-        }
+        const NANOS_PER_SEC: u128 = std::time::Duration::from_secs(1).as_nanos();
+        let nanos = hf_duration.total_nanoseconds();
+        let unsigned_nanos = u128::try_from(nanos).unwrap_or(0);
+
+        let secs: u64 = (unsigned_nanos / NANOS_PER_SEC)
+            .try_into()
+            .unwrap_or(u64::MAX);
+        let subsec_nanos = (unsigned_nanos % NANOS_PER_SEC) as u32;
+
+        std::time::Duration::new(secs, subsec_nanos)
     }
 }
 
@@ -40,6 +41,6 @@ impl From<std::time::Duration> for Duration {
     /// 1. If the duration is negative, this will return a std::time::Duration::ZERO.
     /// 2. If the duration larger than the MAX duration, this will return std::time::Duration::MAX
     fn from(std_duration: std::time::Duration) -> Self {
-        std_duration.as_secs_f64() * Unit::Second
+        Duration::from_total_nanoseconds(std_duration.as_nanos().try_into().unwrap_or(i128::MAX))
     }
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -531,6 +531,32 @@ fn std_time_duration() {
     // Check that a negative hifitime duration is zero in std time
     let std_duration: StdDuration = (-hf_duration).into();
     assert_eq!(std_duration, StdDuration::ZERO);
+
+    // Check that a StdDuration::MAX, which is a longer duration than
+    // hifitime::Duration, is hifitime::Duration::MAX on conversion
+    assert_eq!(Duration::MAX, Into::<Duration>::into(StdDuration::MAX));
+
+    // Check that when Duration::MAX is converteed into StdDuration,
+    // its conversion is equivalent to a StdDuration of
+    // 103407943680000 seconds
+    assert_eq!(
+        StdDuration::from_secs(103407943680000),
+        Into::<StdDuration>::into(Duration::MAX)
+    );
+
+    // Check that conversions are in fact lossless at large durations.
+    // This tests large numbers below the seconds equivalent when converting
+    // Duration::MAX into a StdDuration
+    let std_duration: StdDuration = StdDuration::from_secs(100000000000000);
+    let hf_duration: Duration = std_duration.into();
+    assert_eq!(StdDuration::from_secs(100000000000000), hf_duration.into());
+
+    let std_duration: StdDuration = StdDuration::from_secs(103407943680000 - 1);
+    let hf_duration: Duration = std_duration.into();
+    assert_eq!(
+        StdDuration::from_secs(103407943680000 - 1),
+        hf_duration.into()
+    );
 }
 
 #[test]


### PR DESCRIPTION
This works towards closing #337 by making the implementations of `From<std::time::Duration> for Duration` and `From<Duration> for std::time::Duration` lossless. Thank you!