### PR TITLE
359 replace reqwest with ureq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,17 +35,19 @@ lexical-core = { version = "1.0.1", default-features = false, features = [
     "parse-integers",
     "parse-floats",
 ] }
-reqwest = { version = "0.12", features = ["blocking", "json"], optional = true }
 tabled = { version = "0.17.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 web-time = { version = "1.0.0", optional = true }
 snafu = { version = "0.8.2", default-features = false }
+ureq = { version = "3.0.10", default-features = false, optional = true, features = [
+    "rustls",
+] }
 
 [features]
 default = ["std"]
 std = ["serde", "serde_derive", "web-time", "snafu/std", "snafu/backtrace"]
 python = ["std", "pyo3", "ut1"]
-ut1 = ["std", "reqwest", "tabled", "openssl"]
+ut1 = ["std", "ureq", "tabled", "openssl"]
 
 [dev-dependencies]
 serde_json = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ web-sys = { version = "0.3", features = [
     'PerformanceTiming',
 ] }
 
+[target.aarch64-unknown-linux-gnu.env]
+CFLAGS="-D__ARM_ARCH=8"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 

--- a/src/epoch/ut1.rs
+++ b/src/epoch/ut1.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
-use ureq::Agent;
+use ureq::get;
 use ureq::Error;
 
 use tabled::settings::Style;
@@ -91,20 +91,8 @@ impl Ut1Provider {
     pub fn download_from_jpl(version: &str) -> Result<Self, HifitimeError> {
         let url = format!("https://eop2-external.jpl.nasa.gov/eop2/{}", version);
 
-        let config = Agent::config_builder()
-            .timeout_global(Some(Duration::from_seconds(10.).into()))
-            .build();
-        let agent: Agent = config.into();
-
-        let a = agent
-            .get(url)
-            .header(
-            "User-Agent", 
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36"
-            )
-            .call();
-
-        match a {
+        // Download the file
+        match get(url).call() {
             Ok(resp) => Self::from_eop_data(resp.into_body().read_to_string().expect(
                 format!("failed to read response body from JPL for version {version}",).as_str(),
             )),

--- a/src/epoch/ut1.rs
+++ b/src/epoch/ut1.rs
@@ -89,8 +89,19 @@ impl Ut1Provider {
 
     /// Build a UT1 provider by downloading the data from <https://eop2-external.jpl.nasa.gov/eop2/latest_eop2.long> (long time scale UT1 data) and parsing it.
     pub fn download_from_jpl(version: &str) -> Result<Self, HifitimeError> {
-        println!("http://eop2-external.jpl.nasa.gov/eop2/{}", version);
-        match get(format!("https://eop2-external.jpl.nasa.gov/eop2/{}", version)).call() {
+        let a = get(format!(
+            "https://eop2-external.jpl.nasa.gov/eop2/{}",
+            version
+        ))
+        .header(
+            "User-Agent",
+            format!("hifitime/{}", env!("CARGO_PKG_VERSION")),
+        )
+        .call();
+
+        println!("a: {:?}", a);
+
+        match a {
             Ok(resp) => Self::from_eop_data(resp.into_body().read_to_string().expect(
                 format!("failed to read response body from JPL for version {version}",).as_str(),
             )),

--- a/src/epoch/ut1.rs
+++ b/src/epoch/ut1.rs
@@ -93,9 +93,15 @@ impl Ut1Provider {
 
         // Download the file
         match get(url).call() {
-            Ok(resp) => Self::from_eop_data(resp.into_body().read_to_string().expect(
-                format!("failed to read response body from JPL for version {version}",).as_str(),
-            )),
+            Ok(resp) => {
+                let Ok(jpl_response) = resp.into_body().read_to_string() else {
+                    return Err(HifitimeError::Parse {
+                        source: ParsingError::UnknownFormat,
+                        details: "when reading EOP2 file from JPL",
+                    });
+                };
+                Self::from_eop_data(jpl_response)
+            }
             Err(Error::StatusCode(code)) => Err(HifitimeError::Parse {
                 source: ParsingError::DownloadError { code: code },
                 details: "when downloading EOP2 file from JPL",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,7 +17,7 @@ use std::io::ErrorKind as IOError;
 use lexical_core::Error as LexicalError;
 
 #[cfg(feature = "ut1")]
-use reqwest::StatusCode;
+use ureq::Error as UreqError;
 
 use crate::Weekday;
 
@@ -90,7 +90,7 @@ pub enum ParsingError {
     },
     #[cfg(feature = "ut1")]
     DownloadError {
-        code: StatusCode,
+        code: u16,
     },
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,9 +16,6 @@ use std::io::ErrorKind as IOError;
 
 use lexical_core::Error as LexicalError;
 
-#[cfg(feature = "ut1")]
-use ureq::Error as UreqError;
-
 use crate::Weekday;
 
 /// Errors handles all oddities which may occur in this library.

--- a/tests/ut1.rs
+++ b/tests/ut1.rs
@@ -31,7 +31,7 @@ fn test_ut1_from_jpl() {
     use hifitime::Epoch;
 
     // Download a specific version of the UT1 file
-    let provider = Ut1Provider::download_from_jpl("221222_190002-marge_eop2.short").unwrap();
+    let provider = Ut1Provider::download_from_jpl("2022/221222_190002-marge_eop2.short").unwrap();
 
     println!("{}", provider);
 
@@ -46,6 +46,6 @@ fn test_ut1_from_jpl() {
     let ut1_epoch = epoch.to_ut1(provider);
     assert_eq!(
         format!("{:x}", ut1_epoch),
-        "2022-01-03T03:05:43.789100000 TAI",
+        "2022-01-03T03:05:06.679020600 TAI",
     );
 }


### PR DESCRIPTION
Hi,

This PR is related to issue #359 and replaces the reqwest dependency with ureq, a lighter HTTP client crate.

The overall code change is minimal, as ureq and reqwest share a very similar API. Although I didn’t perform any detailed timing benchmarks, the execution should now be slightly faster since the tokio runtime is no longer being initialized.

Additionally, I fixed the UT1 test related to the JPL request. After switching to ureq, the test started returning a 403 Forbidden error for the JPL file version 221222_190002. It turned out that the file had been moved into a 2022/ subdirectory. I’m not sure why this didn’t cause an issue previously with reqwest. In any case, I updated the test URL to include the correct subdirectory path (2022/) in order to resolve the problem. The test now performs the correct conversion, consistent with the corresponding Astropy-based comment.

Let me know if anything needs adjusting!