### PR TITLE
Correct UTC import in Python unit tests

### DIFF
--- a/tests/python/test_epoch.py
+++ b/tests/python/test_epoch.py
@@ -36,7 +36,7 @@ def test_strtime():
 def test_utcnow():
     epoch = Epoch.system_now()
     try:
-        dt = datetime.now(datetime.UTC)
+        dt = datetime.now(timezone.utc)
     except Exception:
         dt = datetime.utcnow()
 
@@ -65,7 +65,7 @@ def test_time_series():
         print(f"#{num}:\t{epoch}")
 
     assert num == 10
-    # Once consummed, the iterator in the time series will be different,
+    # Once consumed, the iterator in the time series will be different,
     # so the pickling will return something different
     assert pickle.loads(pickle.dumps(time_series)) != time_series
 


### PR DESCRIPTION
# PR Summary
This PR fixes a bug where `datetime.UTC` caused an `AttributeError` in Python versions where `UTC` is not a class attribute. The error occurred because `UTC` is accessed via the `datetime` module (`datetime.UTC`), not the `datetime.datetime` class. Replaced `datetime.UTC` with the widely compatible `timezone.utc` to ensure cross-version compatibility (we could import `UTC` from `datetime` instead). Also fixed a small typo along the way.