### PR TITLE
Docs: Clarify strftime Python compatibility

### DIFF
--- a/hifitime.pyi
+++ b/hifitime.pyi
@@ -687,7 +687,7 @@ Epoch::from_gregorian_tai_hms(2022, 5, 20, 18, 0, 0)
         """Returns the seconds of the Gregorian representation  of this epoch in the time scale it was initialized in."""
 
     def strftime(self, format_str: str) -> str:
-        """Equivalent to `datetime.strftime`, refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options"""
+        """Formats the epoch according to the given format string. Supports a subset of C89 and hifitime-specific format codes. Refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for available format options"""
 
     @staticmethod
     def strptime(epoch_str: str, format_str: str) -> Epoch:

--- a/src/epoch/python.rs
+++ b/src/epoch/python.rs
@@ -392,7 +392,7 @@ impl Epoch {
         Self::from_format_str(&epoch_str, &format_str).map_err(|e| PyErr::from(e))
     }
 
-    /// Equivalent to `datetime.strftime`, refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for format options
+    /// Formats the epoch according to the given format string. Supports a subset of C89 and hifitime-specific format codes. Refer to <https://docs.rs/hifitime/latest/hifitime/efmt/format/struct.Format.html> for available format options.
     /// :type format_str: str
     /// :rtype: str
     fn strftime(&self, format_str: String) -> PyResult<String> {


### PR DESCRIPTION
The docstring for the Python binding of `Epoch.strftime` previously claimed equivalence with Python's `datetime.strftime`. This is not entirely accurate, as `hifitime` supports a subset of C89-style format codes along with some hifitime-specific ones, but does not implement all of Python's directives (e.g., %W, %U, %G, %V, locale-specific formats).

This commit updates the docstrings in `src/epoch/python.rs` and `hifitime.pyi` to more accurately describe the supported formatting capabilities and directs you to the hifitime documentation for the list of available format codes.

Fixes #384.