### PR TITLE
Enable serde for kani

### DIFF
--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -27,5 +27,5 @@ jobs:
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
 
-      # - name: Kani Rust Verifier
-      #   uses: model-checking/kani-github-action@0.23
+      - name: Kani Rust Verifier
+        uses: model-checking/kani-github-action@latest

--- a/.github/workflows/formal_verification.yml
+++ b/.github/workflows/formal_verification.yml
@@ -28,4 +28,4 @@ jobs:
           mv Cargo.toml.new Cargo.toml
 
       - name: Kani Rust Verifier
-        uses: model-checking/kani-github-action@latest
+        uses: model-checking/kani-github-action@v1.1

--- a/.github/workflows/kani-builder.yml
+++ b/.github/workflows/kani-builder.yml
@@ -13,10 +13,9 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  formal-verif:
+  formal-verif-build:
     name: Formal Verification
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -27,5 +26,7 @@ jobs:
           sed '17d' Cargo.toml > Cargo.toml.new
           mv Cargo.toml.new Cargo.toml
 
+      # Only ensure that Kani can build successfully
       - name: Kani Rust Verifier
         uses: model-checking/kani-github-action@v1.1
+        args: --only-codegen

--- a/.github/workflows/kani-builder.yml
+++ b/.github/workflows/kani-builder.yml
@@ -29,4 +29,5 @@ jobs:
       # Only ensure that Kani can build successfully
       - name: Kani Rust Verifier
         uses: model-checking/kani-github-action@v1.1
-        args: --only-codegen
+        with:
+          args: --only-codegen

--- a/.github/workflows/kani-builder.yml
+++ b/.github/workflows/kani-builder.yml
@@ -1,4 +1,4 @@
-name: Formal Verification Workflow
+name: Kani Formal Verification Build
 
 on:
   push:

--- a/.github/workflows/weekly-kani-checker.yaml
+++ b/.github/workflows/weekly-kani-checker.yaml
@@ -21,4 +21,5 @@ jobs:
 
       - name: Kani Rust Verifier
         uses: model-checking/kani-github-action@v1.1
-        args: --fail-fast -j 8
+        with:
+          args: --fail-fast -j 8

--- a/.github/workflows/weekly-kani-checker.yaml
+++ b/.github/workflows/weekly-kani-checker.yaml
@@ -1,4 +1,4 @@
-name: Daily Workflow
+name: Weekly Kani formal verifier Workflow
 
 on:
   workflow_dispatch:

--- a/.github/workflows/weekly-kani-checker.yaml
+++ b/.github/workflows/weekly-kani-checker.yaml
@@ -1,0 +1,24 @@
+name: Daily Workflow
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  kani-formal-model-checker:
+    name: Formal Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Clean Cargo.toml for Kani
+        run: |
+          # Remove `cdylib` from targets in Cargo.toml because it confuses Kani
+          sed '17d' Cargo.toml > Cargo.toml.new
+          mv Cargo.toml.new Cargo.toml
+
+      - name: Kani Rust Verifier
+        uses: model-checking/kani-github-action@v1.1
+        args: --fail-fast -j 8

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -25,7 +25,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
 use core::str::FromStr;
 
-#[cfg(not(kani))]
 pub mod parse;
 
 #[cfg(feature = "python")]
@@ -110,7 +109,6 @@ impl Default for Duration {
     }
 }
 
-#[cfg(not(kani))]
 #[cfg(feature = "serde")]
 impl Serialize for Duration {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -122,7 +120,6 @@ impl Serialize for Duration {
     }
 }
 
-#[cfg(not(kani))]
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/kani_verif.rs
+++ b/src/kani_verif.rs
@@ -41,7 +41,7 @@ mod kani_harnesses {
     }
 
     #[kani::proof]
-    fn kani_harness_TimeSeries_exclusive() {
+    fn kani_harness_time_series_exclusive() {
         let start: Epoch = kani::any();
         let end: Epoch = kani::any();
         let step: Duration = kani::any();
@@ -49,7 +49,7 @@ mod kani_harnesses {
     }
 
     #[kani::proof]
-    fn kani_harness_TimeSeries_inclusive() {
+    fn kani_harness_time_series_inclusive() {
         let start: Epoch = kani::any();
         let end: Epoch = kani::any();
         let step: Duration = kani::any();


### PR DESCRIPTION
In a much older version of kani, serde wouldn't compile. This seems to have been fixed. It should fix #394 .

This PR also reenables kani in the CI.