### PR TITLE
Fix Python type hints in Rustdoc comments

### DIFF
--- a/src/duration/python.rs
+++ b/src/duration/python.rs
@@ -22,7 +22,7 @@ impl Duration {
     #[must_use]
     /// Returns the centuries and nanoseconds of this duration
     /// NOTE: These items are not public to prevent incorrect durations from being created by modifying the values of the structure directly.
-    /// :rtype: typing.Tuple
+    /// :rtype: tuple
     #[pyo3(name = "to_parts")]
     pub const fn py_to_parts(&self) -> (i16, u64) {
         (self.centuries, self.nanoseconds)
@@ -69,7 +69,7 @@ impl Duration {
 
     /// Decomposes a Duration in its sign, days, hours, minutes, seconds, ms, us, ns
     ///
-    /// :rtype: typing.Tuple
+    /// :rtype: tuple
     #[pyo3(name = "decompose")]
     pub fn py_decompose(&self) -> (i8, u64, u64, u64, u64, u64, u64, u64) {
         self.decompose()
@@ -289,17 +289,17 @@ impl Duration {
     /// assert Duration.MIN() - one_ns == Duration.MIN()
     /// ```
     ///
-    /// :rtype: hifitime.Duration
+    /// :rtype: Duration
     fn __sub__(&self, other: Self) -> Duration {
         *self - other
     }
 
-    /// :rtype: hifitime.Duration
+    /// :rtype: Duration
     fn __mul__(&self, other: f64) -> Duration {
         *self * other
     }
 
-    /// :rtype: hifitime.Duration
+    /// :rtype: Duration
     fn __div__(&self, other: f64) -> Duration {
         *self / other
     }

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -378,7 +378,7 @@ impl Epoch {
 
     #[must_use]
     /// Returns the TAI parts of this duration
-    /// :rtype: typing.Tuple
+    /// :rtype: tuple
     pub fn to_tai_parts(&self) -> (i16, u64) {
         self.to_tai_duration().to_parts()
     }
@@ -869,7 +869,7 @@ impl Epoch {
 
     #[must_use]
     /// Returns the year and the days in the year so far (days of year).
-    /// :rtype: typing.Tuple
+    /// :rtype: tuple
     pub fn year_days_of_year(&self) -> (i32, f64) {
         (self.year(), self.day_of_year())
     }

--- a/src/epoch/ops.rs
+++ b/src/epoch/ops.rs
@@ -148,7 +148,7 @@ impl Epoch {
     /// Converts this epoch into the time of week, represented as a rolling week counter into that time scale
     /// and the number of nanoseconds elapsed in current week (since closest Sunday midnight).
     /// This is usually how GNSS receivers describe a timestamp.
-    /// :rtype: typing.Tuple[int]
+    /// :rtype: tuple
     pub fn to_time_of_week(&self) -> (u32, u64) {
         let total_nanoseconds = self.duration.total_nanoseconds();
         let weeks = total_nanoseconds / NANOSECONDS_PER_DAY as i128 / Weekday::DAYS_PER_WEEK_I128;


### PR DESCRIPTION
Ensured that :rtype: and :type: flags in Rustdoc comments accurately reflect the Rust types for Python API generation.

- Corrected `typing.Tuple` to `tuple` for functions returning Rust tuples.
- Standardized `hifitime.Duration` to `Duration`.
- Verified other type hints for correctness against their corresponding Rust types.