### PR TITLE
Check max days in feb month during a leap year

### DIFF
--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -699,8 +699,12 @@ pub const fn is_gregorian_valid(
     {
         return false;
     }
-    if day > usual_days_per_month(month) && (month != 2 || !is_leap_year(year)) {
-        // Not in February or not a leap year
+    let days_per_month = if month == 2 && is_leap_year(year) {
+        29
+    } else {
+        usual_days_per_month(month)
+    };
+    if day > days_per_month {
         return false;
     }
     true

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2379,5 +2379,4 @@ fn test_et_continuity_around_j2000() {
 #[should_panic]
 fn test_regression_gh_440_february_epoch() {
     let _ = Epoch::from_gregorian_tai(2024, 2, 31, 00, 00, 0, 0);
-}   
-
+}

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2374,3 +2374,10 @@ fn test_et_continuity_around_j2000() {
         epoch_after_j2000_et - round_trip_after
     );
 }
+
+#[test]
+#[should_panic]
+fn test_regression_gh_440_february_epoch() {
+    let _ = Epoch::from_gregorian_tai(2024, 2, 31, 00, 00, 0, 0);
+}   
+

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -1113,7 +1113,7 @@ fn ops() {
 #[test]
 fn test_range() {
     let start = Epoch::from_gregorian_utc_hms(2012, 2, 7, 11, 22, 33);
-    let middle = Epoch::from_gregorian_utc_hms(2012, 2, 30, 0, 11, 22);
+    let middle = Epoch::from_gregorian_utc_hms(2012, 2, 29, 0, 11, 22);
     let end = Epoch::from_gregorian_utc_hms(2012, 3, 7, 11, 22, 33);
     let rng = start..end;
     assert_eq!(rng, core::ops::Range { start, end });


### PR DESCRIPTION
This will now give out a invalid georgian date : 
```
    let e = Epoch::from_gregorian_tai(2024, 2, 30, 00, 00, 0,0);
    println!("{e}");
```

Previously, Feb 30 and Feb 31 in an leap year were considered valid. 