### PR TITLE
Non-leap time scales error on init with leap second 

### DIFF
--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -274,7 +274,9 @@ impl Epoch {
         nanos: u32,
         time_scale: TimeScale,
     ) -> Result<Self, HifitimeError> {
-        if !is_gregorian_valid(year, month, day, hour, minute, second, nanos) {
+        if !is_gregorian_valid(year, month, day, hour, minute, second, nanos)
+            || (second == 60 && !time_scale.uses_leap_seconds())
+        {
             return Err(HifitimeError::InvalidGregorianDate);
         }
 
@@ -699,7 +701,12 @@ pub const fn is_gregorian_valid(
     {
         return false;
     }
-    if day > usual_days_per_month(month) && (month != 2 || !is_leap_year(year)) {
+    let days_per_month = if month == 2 && is_leap_year(year) {
+        29
+    } else {
+        usual_days_per_month(month)
+    };
+    if day > days_per_month {
         // Not in February or not a leap year
         return false;
     }

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -2396,9 +2396,3 @@ fn test_regression_gh_440_february_epoch() {
 fn test_regression_gh_440_60s_non_leap() {
     let _ = Epoch::from_gregorian_tai(1971, 12, 31, 23, 59, 60, 0);
 }
-
-#[test]
-#[should_panic]
-fn test_regression_gh_440_invalid_feb() {
-    let _ = Epoch::from_gregorian_tai(2024, 2, 31, 00, 00, 0, 0);
-}

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -305,7 +305,7 @@ fn julian_epoch() {
     // HEASARC reports 57203.99998843 but hifitime computes 57203.99998842592 (three additional)
     // significant digits.
     assert!(
-        (Epoch::from_gregorian_tai_hms(2015, 6, 30, 23, 59, 59).to_mjd_tai_days()
+        (Epoch::from_gregorian_utc_hms(2015, 6, 30, 23, 59, 59).to_mjd_utc_days()
             - 57_203.999_988_425_92)
             .abs()
             < f64::EPSILON,
@@ -313,10 +313,20 @@ fn julian_epoch() {
     );
 
     // X-Val: https://heasarc.gsfc.nasa.gov/cgi-bin/Tools/xTime/xTime.pl?time_in_i=2015-06-30+23%3A59%3A60&time_in_c=&time_in_d=&time_in_j=&time_in_m=&time_in_sf=&time_in_wf=&time_in_sl=&time_in_snu=&time_in_s=&time_in_h=&time_in_n=&time_in_f=&time_in_sz=&time_in_ss=&time_in_sn=&timesys_in=u&timesys_out=u&apply_clock_offset=yes
+    // IMPORTANT: HEASARC leaps forward; hifitime leaps backward. Hence, on the 60th second, hifitime "cancels" this second
+    // in non-leap-second time scales. Handling of leap seconds is implementation specific.
+    // This is why the expected MJD at the 60th second equals that of the 59th seconds.
+
     assert!(
-        (Epoch::from_gregorian_tai_hms(2015, 6, 30, 23, 59, 60).to_mjd_tai_days()
+        (Epoch::from_gregorian_utc_hms(2015, 6, 30, 23, 59, 60).to_mjd_utc_days()
             - 57_203.999_988_425_92)
             .abs()
+            < f64::EPSILON,
+        "Incorrect July 2015 leap second MJD computed, with backward leap second"
+    );
+    // X-Val: https://heasarc.gsfc.nasa.gov/cgi-bin/Tools/xTime/xTime.pl?time_in_i=2015-07-01+00%3A00%3A00&time_in_c=&time_in_d=&time_in_j=&time_in_m=&time_in_sf=&time_in_wf=&time_in_sl=&time_in_snu=&time_in_s=&time_in_h=&time_in_n=&time_in_f=&time_in_sz=&time_in_ss=&time_in_sn=&timesys_in=u&timesys_out=u&apply_clock_offset=yes
+    assert!(
+        (Epoch::from_gregorian_utc_at_midnight(2015, 7, 1).to_mjd_utc_days() - 57_204.0).abs()
             < f64::EPSILON,
         "Incorrect July 2015 leap second MJD computed"
     );
@@ -1113,7 +1123,7 @@ fn ops() {
 #[test]
 fn test_range() {
     let start = Epoch::from_gregorian_utc_hms(2012, 2, 7, 11, 22, 33);
-    let middle = Epoch::from_gregorian_utc_hms(2012, 2, 30, 0, 11, 22);
+    let middle = Epoch::from_gregorian_utc_hms(2012, 2, 29, 0, 11, 22);
     let end = Epoch::from_gregorian_utc_hms(2012, 3, 7, 11, 22, 33);
     let rng = start..end;
     assert_eq!(rng, core::ops::Range { start, end });
@@ -2373,4 +2383,22 @@ fn test_et_continuity_around_j2000() {
         round_trip_after,
         epoch_after_j2000_et - round_trip_after
     );
+}
+
+#[test]
+#[should_panic]
+fn test_regression_gh_440_february_epoch() {
+    let _ = Epoch::from_gregorian_tai(2024, 2, 31, 00, 00, 0, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_regression_gh_440_60s_non_leap() {
+    let _ = Epoch::from_gregorian_tai(1971, 12, 31, 23, 59, 60, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_regression_gh_440_invalid_feb() {
+    let _ = Epoch::from_gregorian_tai(2024, 2, 31, 00, 00, 0, 0);
 }


### PR DESCRIPTION
Previously, one could initialize an Epoch with the 60th second on a leap day even if the selected time scale did not support leap seconds. This PR makes this an error.

Importantly, this PR also fixes an error in the `julian_epoch` test where an epoch was initialized on the leap second but ... in TAI. There is no leap second in TAI, so this initialization should fail. The test case was also expanded to confirm the computation of Modified Julian Dates using NASA HEASARC, with an extra test and a clarification that leap second management is implementation dependent.

Thanks for the report @ephraim71 !