### PR TITLE
Remove 1972 from january_years

### DIFF
--- a/src/epoch/gregorian.rs
+++ b/src/epoch/gregorian.rs
@@ -716,7 +716,7 @@ pub const fn is_gregorian_valid(
 const fn january_years(year: i32) -> bool {
     matches!(
         year,
-        1972 | 1973
+              1973
             | 1974
             | 1975
             | 1976


### PR DESCRIPTION
Leap second was between December 1972 and January 1973
https://en.wikipedia.org/wiki/Leap_second