### PR TITLE
Perf: Borrow `Ut1Provider`, `O(log n)` UT1 offset lookup, and faster EOP parsing

### DIFF
--- a/tests/ut1.rs
+++ b/tests/ut1.rs
@@ -18,7 +18,7 @@ fn test_ut1_from_file() {
     //
     let epoch = Epoch::from_str("2022-01-03 03:05:06.7891").unwrap();
     assert_eq!(
-        format!("{:x}", epoch.to_ut1(provider)),
+        format!("{:x}", epoch.to_ut1(&provider)),
         "2022-01-03T03:05:06.679020600 TAI"
     );
 }
@@ -43,7 +43,7 @@ fn test_ut1_from_jpl() {
     // >>>
     //
     let epoch = Epoch::from_str("2022-01-03 03:05:06.7891 UTC").unwrap();
-    let ut1_epoch = epoch.to_ut1(provider);
+    let ut1_epoch = epoch.to_ut1(&provider);
     assert_eq!(
         format!("{:x}", ut1_epoch),
         "2022-01-03T03:05:06.679020600 TAI",


### PR DESCRIPTION
## Summary
This PR reduces the overhead of UT1 conversions by:
- **Borrowing** `Ut1Provider` instead of moving it (no more large `Vec` clones on hot paths).
- Replacing the reverse linear scan in `Epoch::ut1_offset` with an **`O(log n)`** lookup using `slice::partition_point`, plus a **fast-path** when the query epoch is ≥ the last record.
- Making the EOP parser (`Ut1Provider::from_eop_data`) **single-pass** with **no per-line allocation** and a **conditional sort** (only sort if input is detected out of order).
- Adding ergonomic, zero-copy iteration helpers on `Ut1Provider` (`iter`, `as_slice`, and `IntoIterator for &Ut1Provider`).

These changes eliminate unnecessary cloning, reduce allocations, and make UT1 offset queries scale with the number of records.

## Breaking change & Migration

This PR introduces a **small breaking change**: UT1 conversion functions now take a
**borrowed** provider (`&Ut1Provider`) instead of owning it. The migration is a
one-liner at each call site.

### What changed

```diff
- pub fn from_ut1_duration(duration: Duration, provider: Ut1Provider) -> Self
+ pub fn from_ut1_duration(duration: Duration, provider: &Ut1Provider) -> Self

- pub fn to_ut1_duration(&self, provider: Ut1Provider) -> Duration
+ pub fn to_ut1_duration(&self, provider: &Ut1Provider) -> Duration

- pub fn to_ut1(&self, provider: Ut1Provider) -> Self
+ pub fn to_ut1(&self, provider: &Ut1Provider) -> Self
```

close #418 