### PR TITLE
Make unit constructors for `Duration` const-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hifitime"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Christopher Rabotin <christopher.rabotin@gmail.com>"]
 description = "Ultra-precise date and time handling in Rust for scientific applications with leap second support"
 homepage = "https://nyxspace.com/"
@@ -17,7 +17,7 @@ edition = "2021"
 crate-type = ["rlib"]
 name = "hifitime"
 
-# `cdylib` is useful only when the `std` feature is on.  
+# `cdylib` is useful only when the `std` feature is on.
 # In `no_std`, dynamic‑link targets face “unwinding panics not supported”  https://github.com/nyx-space/hifitime/issues/343
 [target.'cfg(feature = "std")'.lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -321,7 +321,7 @@ impl Duration {
     }
 
     /// Return the normalized equivalent of a [Duration].
-    const fn as_normalized(&self) -> Self {
+    const fn as_normalized(self) -> Self {
         let mut normalized_self = *self;
 
         let extra_centuries = self.nanoseconds / NANOSECONDS_PER_CENTURY;

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -167,7 +167,7 @@ impl Duration {
 
     #[must_use]
     /// Create a normalized duration from its parts
-    pub fn from_parts(centuries: i16, nanoseconds: u64) -> Self {
+    pub const fn from_parts(centuries: i16, nanoseconds: u64) -> Self {
         let mut me = Self {
             centuries,
             nanoseconds,
@@ -178,16 +178,16 @@ impl Duration {
 
     #[must_use]
     /// Converts the total nanoseconds as i128 into this Duration (saving 48 bits)
-    pub fn from_total_nanoseconds(nanos: i128) -> Self {
+    pub const fn from_total_nanoseconds(nanos: i128) -> Self {
         // In this function, we simply check that the input data can be casted. The `normalize` function will check whether more work needs to be done.
         if nanos == 0 {
             Self::ZERO
         } else {
-            let centuries_i128 = nanos.div_euclid(NANOSECONDS_PER_CENTURY.into());
-            let remaining_nanos_i128 = nanos.rem_euclid(NANOSECONDS_PER_CENTURY.into());
-            if centuries_i128 > i16::MAX.into() {
+            let centuries_i128 = nanos.div_euclid(NANOSECONDS_PER_CENTURY as i128);
+            let remaining_nanos_i128 = nanos.rem_euclid(NANOSECONDS_PER_CENTURY as i128);
+            if centuries_i128 > (i16::MAX as i128) {
                 Self::MAX
-            } else if centuries_i128 < i16::MIN.into() {
+            } else if centuries_i128 < (i16::MIN as i128) {
                 Self::MIN
             } else {
                 // We know that the centuries fit, and we know that the nanos are less than the number
@@ -200,7 +200,7 @@ impl Duration {
 
     #[must_use]
     /// Create a new duration from the truncated nanoseconds (+/- 2927.1 years of duration)
-    pub fn from_truncated_nanoseconds(nanos: i64) -> Self {
+    pub const fn from_truncated_nanoseconds(nanos: i64) -> Self {
         if nanos < 0 {
             let ns = nanos.unsigned_abs();
             // Note: i64::MIN corresponds to a duration just past -3 centuries, so we can't hit the Duration::MIN here.
@@ -217,38 +217,38 @@ impl Duration {
 
     /// Creates a new duration from the provided number of days
     #[must_use]
-    pub fn from_days(value: f64) -> Self {
-        value * Unit::Day
+    pub const fn from_days(value: f64) -> Self {
+        Unit::Day.const_multiply(value)
     }
 
     /// Creates a new duration from the provided number of hours
     #[must_use]
-    pub fn from_hours(value: f64) -> Self {
-        value * Unit::Hour
+    pub const fn from_hours(value: f64) -> Self {
+        Unit::Hour.const_multiply(value)
     }
 
     /// Creates a new duration from the provided number of seconds
     #[must_use]
-    pub fn from_seconds(value: f64) -> Self {
-        value * Unit::Second
+    pub const fn from_seconds(value: f64) -> Self {
+        Unit::Second.const_multiply(value)
     }
 
     /// Creates a new duration from the provided number of milliseconds
     #[must_use]
-    pub fn from_milliseconds(value: f64) -> Self {
-        value * Unit::Millisecond
+    pub const fn from_milliseconds(value: f64) -> Self {
+        Unit::Millisecond.const_multiply(value)
     }
 
     /// Creates a new duration from the provided number of microsecond
     #[must_use]
-    pub fn from_microseconds(value: f64) -> Self {
-        value * Unit::Microsecond
+    pub const fn from_microseconds(value: f64) -> Self {
+        Unit::Microsecond.const_multiply(value)
     }
 
     /// Creates a new duration from the provided number of nanoseconds
     #[must_use]
-    pub fn from_nanoseconds(value: f64) -> Self {
-        value * Unit::Nanosecond
+    pub const fn from_nanoseconds(value: f64) -> Self {
+        Unit::Nanosecond.const_multiply(value)
     }
 
     /// Creates a new duration from its parts. Set the sign to a negative number for the duration to be negative.

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -336,7 +336,7 @@ impl Duration {
                     normalized_self = Self::MAX;
                 }
                 // Else, we're near the MAX but we're within the MAX in nanoseconds, so let's not do anything here.
-            } else if !self.parts_are_equal(Self::MAX) && !self.parts_are_equal(Self::MIN) {
+            } else if !self.parts_are_equal(Self::MIN) {
                 // The bounds are valid as is, no wrapping needed when rem_nanos is not zero.
                 match self.centuries.checked_add(extra_centuries as i16) {
                     Some(centuries) => {

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -326,7 +326,7 @@ impl Duration {
 
         let extra_centuries = self.nanoseconds / NANOSECONDS_PER_CENTURY;
 
-        // We can skip this whole step if the div_euclid shows that we didn't overflow the number of nanoseconds per century
+        // We can skip this whole step if the division shows that we didn't overflow the number of nanoseconds per century
         if extra_centuries > 0 {
             let rem_nanos = self.nanoseconds % NANOSECONDS_PER_CENTURY;
 

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -322,7 +322,7 @@ impl Duration {
 
     /// Return the normalized equivalent of a [Duration].
     const fn as_normalized(self) -> Self {
-        let mut normalized_self = *self;
+        let mut normalized_self = self;
 
         let extra_centuries = self.nanoseconds / NANOSECONDS_PER_CENTURY;
 

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -336,7 +336,7 @@ impl Duration {
                     normalized_self = Self::MAX;
                 }
                 // Else, we're near the MAX but we're within the MAX in nanoseconds, so let's not do anything here.
-            } else if !self.is_equal_to(Self::MAX) && !self.is_equal_to(Self::MIN) {
+            } else if !self.parts_are_equal(Self::MAX) && !self.parts_are_equal(Self::MIN) {
                 // The bounds are valid as is, no wrapping needed when rem_nanos is not zero.
                 match self.centuries.checked_add(extra_centuries as i16) {
                     Some(centuries) => {
@@ -364,7 +364,7 @@ impl Duration {
     /// Note that this only checks whether the fields of `self` and `other` are
     /// the same, not whether they would (if [`Self::normalize`]d) represent
     /// the same duration.
-    const fn is_equal_to(&self, other: Duration) -> bool {
+    const fn parts_are_equal(&self, other: Duration) -> bool {
         self.centuries == other.centuries && self.nanoseconds == other.nanoseconds
     }
 

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -322,7 +322,13 @@ impl Unit {
             Duration::MIN
         } else {
             let total_ns = q * factor;
-            if total_ns.abs() < (i64::MAX as f64) {
+
+            // The following manual `abs()` implementation was added because
+            // `f64::abs()` was not a `const` function in Rust 1.82, which is
+            // used for the MSRV workflow at the time of writing.
+            let absolute_nanoseconds = if total_ns >= 0.0 { total_ns } else { -total_ns };
+
+            if absolute_nanoseconds < (i64::MAX as f64) {
                 Duration::from_truncated_nanoseconds(total_ns as i64)
             } else {
                 Duration::from_total_nanoseconds(total_ns as i128)

--- a/src/timeunits.rs
+++ b/src/timeunits.rs
@@ -296,6 +296,13 @@ impl Mul<f64> for Unit {
     /// 1. If the input value times the unit does not fit on a Duration, then Duration::MAX or Duration::MIN will be returned depending on whether the value would have overflowed or underflowed (respectively).
     /// 2. Floating point operations may round differently on different processors. It's advised to use integer initialization of Durations whenever possible.
     fn mul(self, q: f64) -> Duration {
+        self.const_multiply(q)
+    }
+}
+
+impl Unit {
+    /// `const`-compatible copy of [Self::mul].
+    pub(crate) const fn const_multiply(self, q: f64) -> Duration {
         let factor = match self {
             Unit::Century => NANOSECONDS_PER_CENTURY as f64,
             Unit::Week => NANOSECONDS_PER_DAY as f64 * DAYS_PER_WEEK,


### PR DESCRIPTION
The unit constructors for `Duration` (`from_nanoseconds`, `from_days`, etc.) are made `const`-compatible, allowing `Duration` to be declared as a compile-time constant. This is a fix for issue #422.

# Main Changes

- `Duration::normalize()` uses plain `/` and `%` operators in place of `div_euclid` and `rem_euclid`.

- A const-compatible `Duration::is_equal_to(other: Duration)` is added to replace two (non-)equality checks in `Duration::normalize()`.

- `Duration::from_total_nanoseconds()` is changed to use explicit `as i128` casts instead of `into()`.

- The existing implementation of `Mul<f64> for Unit` is moved to a non-trait `const` method called `Unit::const_multiply`. This method is called by the regular `mul`, and from the unit constructors.

# MSRV Compatibility

Additionally, for compatibility with the MSRV (1.82), the following changes have been made:

- The body of `Duration::normalize(&mut self)` is moved to a new constant method `Duration::to_normalized(&self)`. The existing `normalize(&mut self)` remains non-constant and instead calls `to_normalized()` on the input.

- A call to `f64::abs()` is replaced by a manual if/else implementation, since `f64::abs` was not `const`-compatible in the MSRV.