### PR TITLE
fix: bump snafu version for proper error semantics in no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ lexical-core = { version = "1.0.1", default-features = false, features = [
 tabled = { version = "0.20.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 web-time = { version = "1.0.0", optional = true }
-snafu = { version = "0.8.2", default-features = false }
+snafu = { version = "0.8.5", features = ["rust_1_81"], default-features = false }
 ureq = { version = "3.0.10", default-features = false, optional = true, features = [
     "rustls",
 ] }


### PR DESCRIPTION
the current hifitime error types do not implement the `Error` traits in no_std b/c the functionality to do so in the current version of `snafu` is gated behind a feature flag that requires unstable `cargo` toolchains.

bump our `snafu` version to `0.8.5` and include the `rust_1_81` feature to get generated implementations of `core::error::Error`, which was stabilized in Rust 1.81 (hence the feature name). this is compatible with hifitime's MSRV, which is Rust 1.82 as of v4.0.0.

fixes #441