### PR TITLE
Fix polynomial python implementation

### DIFF
--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -125,9 +125,7 @@ impl fmt::Display for Polynomial {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-#[cfg(feature = "python")]
+#[cfg_attr(feature = "python", pymethods)]
 impl Polynomial {
     /// Create a [Polynomial] structure that is only made of a static offset
     /// :type constant: Duration


### PR DESCRIPTION
There is an issue with the current `Polynomial` implementation which is incorrect and almost forbids using this part of the library along the `python` bindings.