### PR TITLE
Enable strptime parsing for compact strings without separators

### DIFF
--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -225,12 +225,9 @@ impl Format {
                     // Advance the token, unless we're at the end of the tokens.
                     if cur_item_idx < self.num_items {
                         cur_item_idx += 1;
-                        match self.items[cur_item_idx] {
-                            Some(item) => {
-                                cur_item = item;
-                                cur_token = cur_item.token;
-                            }
-                            None => {}
+                        if let Some(item) = self.items[cur_item_idx] {
+                            cur_item = item;
+                            cur_token = cur_item.token;
                         }
                     }
                     idx + 1

--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -631,9 +631,14 @@ fn gh_248_regression() {
     assert_eq!(format!("{e}"), "2023-04-27T12:55:26 UTC");
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_strptime_no_separators() {
     let fmt = Format::from_str("%Y%m%d%H%M%S").unwrap();
     let e = fmt.parse("20270216143714").unwrap();
     assert_eq!(format!("{e}"), "2027-02-16T14:37:14 UTC");
+
+    let fmt = Format::from_str("%Y%m%d").unwrap();
+    let e = fmt.parse("20230102").unwrap();
+    assert_eq!(format!("{e}"), "2023-01-02T00:00:00 UTC");
 }

--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -176,18 +176,29 @@ impl Format {
         let s = s_in.trim();
 
         for (idx, char) in s.char_indices() {
+            let reached_fixed_length = cur_item.sep_char.is_none()
+                && cur_item.second_sep_char.is_none()
+                && !cur_item.optional
+                && cur_token
+                    .fixed_length()
+                    .map(|l| idx >= prev_idx && idx - prev_idx + 1 == l)
+                    .unwrap_or(false);
+
             // We should parse if:
             // 1. we're at the end of the string
             // 2. Or we've hit a non-numeric char and the token is fully numeric
             // 3. Or, token is not numeric (e.g. month name) and the current char is the separator
-            // 4. And, if the length of the current substring is longer than 1 and the char is not the optional separator of the previous token.
+            // 4. Or, we've reached the fixed length of the token and there are no separators
+            // 5. And, if the length of the current substring is longer than 1 and the char is not the optional separator of the previous token.
             if idx == s.len() - 1
                 || ((cur_token.is_numeric() && !char.is_numeric())
                     || (!cur_token.is_numeric() && (cur_item.sep_char_is(char))))
+                || reached_fixed_length
             {
                 // If we've found the second separator of the previous token, let's simply increment the start index of the next substring.
                 if idx == prev_idx
                     && (prev_item.second_sep_char.is_none() || prev_item.second_sep_char_is(char))
+                    && !reached_fixed_length
                 {
                     prev_idx += 1;
                     continue;
@@ -210,9 +221,23 @@ impl Format {
                 prev_item = cur_item;
                 prev_token = cur_token;
 
-                let end_idx = if idx != s.len() - 1 || !char.is_numeric() {
+                let end_idx = if reached_fixed_length {
+                    // Advance the token, unless we're at the end of the tokens.
+                    if cur_item_idx < self.num_items {
+                        cur_item_idx += 1;
+                        match self.items[cur_item_idx] {
+                            Some(item) => {
+                                cur_item = item;
+                                cur_token = cur_item.token;
+                            }
+                            None => {}
+                        }
+                    }
+                    idx + 1
+                } else if idx != s.len() - 1 || !char.is_numeric() {
                     // Only advance the token if we aren't at the end of the string
-                    if cur_item.sep_char_is_not(char)
+                    if !reached_fixed_length
+                        && cur_item.sep_char_is_not(char)
                         && (cur_item.second_sep_char.is_none()
                             || (cur_item.second_sep_char_is_not(char)))
                     {
@@ -337,7 +362,8 @@ impl Format {
                 prev_idx = idx + 1;
                 // If we are about to parse an hours offset, we need to set the sign now.
                 if cur_token == Token::OffsetHours {
-                    if &s[idx..idx + 1] == "-" {
+                    let sign_idx = if reached_fixed_length { idx + 1 } else { idx };
+                    if sign_idx < s.len() && &s[sign_idx..sign_idx + 1] == "-" {
                         offset_sign = -1;
                     }
                     prev_idx += 1;
@@ -603,4 +629,11 @@ fn gh_248_regression() {
     let e = Epoch::from_format_str("2023-117T12:55:26", "%Y-%jT%H:%M:%S").unwrap();
 
     assert_eq!(format!("{e}"), "2023-04-27T12:55:26 UTC");
+}
+
+#[test]
+fn test_strptime_no_separators() {
+    let fmt = Format::from_str("%Y%m%d%H%M%S").unwrap();
+    let e = fmt.parse("20270216143714").unwrap();
+    assert_eq!(format!("{e}"), "2027-02-16T14:37:14 UTC");
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -279,4 +279,21 @@ impl Token {
                 | Token::MonthNameShort
         )
     }
+
+    pub(crate) const fn fixed_length(self) -> Option<usize> {
+        match self {
+            Token::Year => Some(4),
+            Token::YearShort
+            | Token::Month
+            | Token::Day
+            | Token::Hour
+            | Token::Minute
+            | Token::Second
+            | Token::OffsetHours
+            | Token::OffsetMinutes => Some(2),
+            Token::DayOfYearInteger => Some(3),
+            Token::WeekdayDecimal => Some(1),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
Modified the `hifitime` parser to support date-time strings without separators. This was achieved by introducing a `fixed_length()` method for numeric tokens and updating the parsing loop to trigger extraction when these lengths are reached, provided no separators are specified in the format. A regression test was added and all existing tests were verified to pass.

Fixes #463

---
*PR created automatically by Jules for task [2202959585289676202](https://jules.google.com/task/2202959585289676202) started by @ChristopherRabotin*