### PR TITLE
Timeseries: expose first and last Epochs without consuming iterator

### DIFF
--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -71,12 +71,16 @@ impl TimeSeries {
         }
     }
 
-    /// Returns first [Epoch] (starting point) of this [TimeSeries].
+    /// Returns first [Epoch] of this [TimeSeries], without consuming
+    /// the iterator.
+    #[inline]
     pub fn first_epoch(&self) -> Epoch {
         self.start
     }
 
-    /// Returns last [Epoch] included in this [TimeSeries].
+    /// Returns last [Epoch] of this [TimeSeries], without consuming
+    /// the iterator.
+    #[inline]
     pub fn last_epoch(&self) -> Epoch {
         let mut epoch = self.start + self.duration;
         if !self.incl {

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -347,6 +347,10 @@ mod tests {
 
         let mut count = 0;
         let time_series = TimeSeries::exclusive(start, end, step);
+
+        assert_eq!(time_series.first_epoch(), start, "invalid first epoch");
+        assert_eq!(time_series.last_epoch(), end - step, "invalid last epoch");
+
         for epoch in time_series {
             if count == 0 {
                 assert_eq!(
@@ -372,6 +376,10 @@ mod tests {
 
         let mut count = 0;
         let time_series = TimeSeries::inclusive(start, end, step);
+        
+        assert_eq!(time_series.first_epoch(), start, "invalid first epoch");
+        assert_eq!(time_series.last_epoch(), end, "invalid last epoch");
+
         for epoch in time_series {
             if count == 0 {
                 assert_eq!(

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -376,7 +376,7 @@ mod tests {
 
         let mut count = 0;
         let time_series = TimeSeries::inclusive(start, end, step);
-        
+
         assert_eq!(time_series.first_epoch(), start, "invalid first epoch");
         assert_eq!(time_series.last_epoch(), end, "invalid last epoch");
 
@@ -417,10 +417,16 @@ mod tests {
     #[test]
     fn ts_over_leap_second() {
         let start = Epoch::from_gregorian_utc(2016, 12, 31, 23, 59, 59, 0);
-        let times = TimeSeries::exclusive(start, start + Unit::Second * 5, Unit::Second * 1);
+        let end = start + Unit::Second * 5;
+        let step = Unit::Second * 1;
+
+        let times = TimeSeries::exclusive(start, end, step);
         let expect_end = start + Unit::Second * 4;
         let mut cnt = 0;
         let mut cur_epoch = start;
+
+        assert_eq!(times.first_epoch(), start, "invalid first epoch");
+        assert_eq!(times.last_epoch(), end - step, "invalid last epoch");
 
         for epoch in times {
             cnt += 1;
@@ -434,9 +440,14 @@ mod tests {
     #[test]
     fn ts_backward() {
         let start = Epoch::from_gregorian_utc(2015, 1, 1, 12, 0, 0, 0);
-        let times = TimeSeries::exclusive(start, start + Unit::Second * 5, Unit::Second * 1);
+        let end = start + Unit::Second * 5;
+        let step = Unit::Second * 1;
+        let times = TimeSeries::exclusive(start, end, step);
         let mut cnt = 0;
         let mut cur_epoch = start;
+
+        assert_eq!(times.first_epoch(), start, "invalid first epoch");
+        assert_eq!(times.last_epoch(), end - step, "invalid last epoch");
 
         for epoch in times.rev() {
             cnt += 1;

--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -71,6 +71,21 @@ impl TimeSeries {
         }
     }
 
+    /// Returns first [Epoch] (starting point) of this [TimeSeries].
+    pub fn first_epoch(&self) -> Epoch {
+        self.start
+    }
+
+    /// Returns last [Epoch] included in this [TimeSeries].
+    pub fn last_epoch(&self) -> Epoch {
+        let mut epoch = self.start + self.duration;
+        if !self.incl {
+            // remove one step
+            epoch -= self.step;
+        }
+        epoch
+    }
+
     /// Return an iterator of evenly spaced Epochs, inclusive on start **and** on end.
     /// ```
     /// use hifitime::{Epoch, Unit, TimeSeries};

--- a/tests/timeseries.rs
+++ b/tests/timeseries.rs
@@ -11,6 +11,9 @@ fn test_timeseries() {
     let mut count = 0;
     let time_series = TimeSeries::exclusive(start, end, step);
 
+    assert_eq!(time_series.first_epoch(), start);
+    assert_eq!(time_series.last_epoch(), end - step);
+
     assert_eq!(
         format!("{time_series}"),
         "TimeSeries [2017-01-14T00:00:00 UTC : 2017-01-14T10:00:00 UTC : 2 h]"
@@ -65,6 +68,9 @@ fn test_timeseries() {
     count = 0;
     let time_series = TimeSeries::inclusive(start, end, step);
 
+    assert_eq!(time_series.first_epoch(), start);
+    assert_eq!(time_series.last_epoch(), end);
+
     assert_eq!(
         format!("{time_series}"),
         "TimeSeries [2017-01-14T00:00:00 UTC : 2017-01-14T12:00:00 UTC : 2 h]"
@@ -98,10 +104,16 @@ fn gh131_regression() {
     assert_eq!(times.len(), steps as usize - 1);
     assert_eq!(times.len(), times.size_hint().0);
 
+    assert_eq!(times.first_epoch(), start);
+    assert_eq!(times.last_epoch(), end - step);
+
     // For an _inclusive_ time series, we skip the last item, so it's the steps count
     let times = TimeSeries::inclusive(start, end, step);
     assert_eq!(times.len(), steps as usize);
     assert_eq!(times.len(), times.size_hint().0);
+
+    assert_eq!(times.first_epoch(), start);
+    assert_eq!(times.last_epoch(), end);
 }
 
 #[test]


### PR DESCRIPTION
Hello,

the timeseries object is very convenient for its iteration method, but unfortunately the start and endpoint being private in the current form, makes it almost impossible to use for any other purpose. Would you agree in merging these new functions (or possibly renamed/reworked)