### PR TITLE
timeseries: derive Copy

### DIFF
--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -33,7 +33,7 @@ NOTE: This is taken from itertools: https://docs.rs/itertools-num/0.1.3/src/iter
 /// :type step: Duration
 /// :type inclusive: bool
 #[cfg_attr(kani, derive(kani::Arbitrary))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "hifitime"))]
 pub struct TimeSeries {


### PR DESCRIPTION
Although it is made of copyable objects, the timeseries struct does not derive the Copy trait. Is there any reasons for that ?