### PR TITLE
TimeSeries: derive Hash

### DIFF
--- a/src/timeseries.rs
+++ b/src/timeseries.rs
@@ -33,7 +33,7 @@ NOTE: This is taken from itertools: https://docs.rs/itertools-num/0.1.3/src/iter
 /// :type step: Duration
 /// :type inclusive: bool
 #[cfg_attr(kani, derive(kani::Arbitrary))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "python", pyclass)]
 #[cfg_attr(feature = "python", pyo3(module = "hifitime"))]
 pub struct TimeSeries {


### PR DESCRIPTION
It would be convenient if that object derived that trait as well. Considering it already derives Eq and PartialEq it does not cost anything.