### PR TITLE
fix: rewrite try_truncated_nanoseconds using total_nanoseconds() for correct boundary handling

### DIFF
--- a/src/duration/kani_verif.rs
+++ b/src/duration/kani_verif.rs
@@ -10,7 +10,7 @@
 
 // Here lives all of the formal verification for Duration.
 
-use super::{Duration, DurationError, HifitimeError};
+use super::Duration;
 use crate::NANOSECONDS_PER_CENTURY;
 
 use kani::Arbitrary;
@@ -36,45 +36,8 @@ fn formal_duration_normalize_any() {
 fn formal_duration_truncated_ns_reciprocity() {
     let nanoseconds: i64 = kani::any();
     let dur_from_part = Duration::from_truncated_nanoseconds(nanoseconds);
-
-    let u_ns = dur_from_part.nanoseconds;
-    let centuries = dur_from_part.centuries;
-    if centuries <= -3 {
-        // Then it does not fit on a i64, so this function should return an Underflow error
-        assert_eq!(
-            dur_from_part.try_truncated_nanoseconds(),
-            Err(HifitimeError::Duration {
-                source: DurationError::Underflow,
-            })
-        );
-    } else if centuries >= 3 {
-        // Then it does not fit on a i64, so this function should return an Overflow error
-        assert_eq!(
-            dur_from_part.try_truncated_nanoseconds(),
-            Err(HifitimeError::Duration {
-                source: DurationError::Overflow
-            })
-        );
-    } else if centuries == -1 {
-        // If we are negative by just enough that the centuries is negative, then the truncated seconds
-        // should be the unsigned nanoseconds wrapped by the number of nanoseconds per century.
-
-        let expect_rslt = -((NANOSECONDS_PER_CENTURY - u_ns) as i64);
-
-        let recip_ns = dur_from_part.try_truncated_nanoseconds().unwrap();
-        assert_eq!(recip_ns, expect_rslt);
-    } else if centuries < 0 {
-        // Centuries negative by more than -1: formula is (centuries + 1) * NPC + nanoseconds
-        let expect_rslt = i64::from(centuries + 1) * NANOSECONDS_PER_CENTURY as i64 + u_ns as i64;
-
-        let recip_ns = dur_from_part.try_truncated_nanoseconds().unwrap();
-        assert_eq!(recip_ns, expect_rslt);
-    } else {
-        // Positive duration but enough to fit on an i64.
-        let recip_ns = dur_from_part.try_truncated_nanoseconds().unwrap();
-
-        assert_eq!(recip_ns, nanoseconds);
-    }
+    let recip_ns = dur_from_part.try_truncated_nanoseconds().unwrap();
+    assert_eq!(recip_ns, nanoseconds);
 }
 
 mod tests {

--- a/src/duration/kani_verif.rs
+++ b/src/duration/kani_verif.rs
@@ -39,12 +39,20 @@ fn formal_duration_truncated_ns_reciprocity() {
 
     let u_ns = dur_from_part.nanoseconds;
     let centuries = dur_from_part.centuries;
-    if centuries <= -3 || centuries >= 3 {
-        // Then it does not fit on a i64, so this function should return an error
+    if centuries <= -3 {
+        // Then it does not fit on a i64, so this function should return an Underflow error
         assert_eq!(
             dur_from_part.try_truncated_nanoseconds(),
             Err(HifitimeError::Duration {
                 source: DurationError::Underflow,
+            })
+        );
+    } else if centuries >= 3 {
+        // Then it does not fit on a i64, so this function should return an Overflow error
+        assert_eq!(
+            dur_from_part.try_truncated_nanoseconds(),
+            Err(HifitimeError::Duration {
+                source: DurationError::Overflow
             })
         );
     } else if centuries == -1 {

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -438,10 +438,15 @@ impl Duration {
 
     /// Returns the truncated nanoseconds in a signed 64 bit integer, if the duration fits.
     pub fn try_truncated_nanoseconds(&self) -> Result<i64, HifitimeError> {
-        // If it fits, we know that the nanoseconds also fit. abs() will fail if the centuries are min'ed out.
-        if self.centuries == i16::MIN || self.centuries.abs() >= 3 {
+        // If it fits, we know that the nanoseconds also fit. Negative and positive
+        // overflows are split to return the correct DurationError variant.
+        if self.centuries == i16::MIN || self.centuries <= -3 {
             Err(HifitimeError::Duration {
                 source: DurationError::Underflow,
+            })
+        } else if self.centuries >= 3 {
+            Err(HifitimeError::Duration {
+                source: DurationError::Overflow,
             })
         } else if self.centuries == -1 {
             Ok(-((NANOSECONDS_PER_CENTURY - self.nanoseconds) as i64))

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -438,38 +438,17 @@ impl Duration {
 
     /// Returns the truncated nanoseconds in a signed 64 bit integer, if the duration fits.
     pub fn try_truncated_nanoseconds(&self) -> Result<i64, HifitimeError> {
-        // If it fits, we know that the nanoseconds also fit. Negative and positive
-        // overflows are split to return the correct DurationError variant.
-        if self.centuries == i16::MIN || self.centuries <= -3 {
-            Err(HifitimeError::Duration {
-                source: DurationError::Underflow,
-            })
-        } else if self.centuries >= 3 {
+        let total = self.total_nanoseconds();
+        if total > i64::MAX as i128 {
             Err(HifitimeError::Duration {
                 source: DurationError::Overflow,
             })
-        } else if self.centuries == -1 {
-            Ok(-((NANOSECONDS_PER_CENTURY - self.nanoseconds) as i64))
-        } else if self.centuries >= 0 {
-            match i64::from(self.centuries).checked_mul(NANOSECONDS_PER_CENTURY as i64) {
-                Some(centuries_as_ns) => {
-                    match centuries_as_ns.checked_add(self.nanoseconds as i64) {
-                        Some(truncated_ns) => Ok(truncated_ns),
-                        None => Err(HifitimeError::Duration {
-                            source: DurationError::Overflow,
-                        }),
-                    }
-                }
-                None => Err(HifitimeError::Duration {
-                    source: DurationError::Underflow,
-                }),
-            }
+        } else if total < i64::MIN as i128 {
+            Err(HifitimeError::Duration {
+                source: DurationError::Underflow,
+            })
         } else {
-            // Centuries negative by a decent amount
-            Ok(
-                i64::from(self.centuries + 1) * NANOSECONDS_PER_CENTURY as i64
-                    + self.nanoseconds as i64,
-            )
+            Ok(total as i64)
         }
     }
 

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,5 +1,6 @@
 use hifitime::{
-    Duration, Freq, Frequencies, TimeUnits, Unit, NANOSECONDS_PER_CENTURY, NANOSECONDS_PER_MINUTE,
+    Duration, DurationError, Freq, Frequencies, HifitimeError, TimeUnits, Unit,
+    NANOSECONDS_PER_CENTURY, NANOSECONDS_PER_MINUTE,
 };
 
 #[test]
@@ -692,4 +693,35 @@ fn regression_test_gh_244() {
     assert_eq!(non_zero.ceil(zero), zero);
     // Test that the ceil of a zero duration by a non-zero is non-zero duration.
     assert_eq!(zero.ceil(non_zero), non_zero);
+}
+
+#[test]
+fn regression_test_gh_475() {
+    assert_eq!(
+        Duration::from_parts(3, 0).try_truncated_nanoseconds(),
+        Err(HifitimeError::Duration {
+            source: DurationError::Overflow,
+        })
+    );
+    assert_eq!(
+        Duration::from_parts(i16::MIN, 0).try_truncated_nanoseconds(),
+        Err(HifitimeError::Duration {
+            source: DurationError::Underflow,
+        })
+    );
+    assert_eq!(
+        Duration::from_parts(i16::MAX, 0).try_truncated_nanoseconds(),
+        Err(HifitimeError::Duration {
+            source: DurationError::Overflow,
+        })
+    );
+    assert_eq!(
+        Duration::from_parts(-3, 0).try_truncated_nanoseconds(),
+        Err(HifitimeError::Duration {
+            source: DurationError::Underflow,
+        })
+    );
+    assert!(Duration::from_parts(2, 0)
+        .try_truncated_nanoseconds()
+        .is_ok());
 }

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -721,6 +721,14 @@ fn regression_test_gh_475() {
             source: DurationError::Underflow,
         })
     );
+    assert_eq!(
+        Duration::from_truncated_nanoseconds(i64::MIN).try_truncated_nanoseconds(),
+        Ok(i64::MIN)
+    );
+    assert_eq!(
+        Duration::from_truncated_nanoseconds(i64::MAX).try_truncated_nanoseconds(),
+        Ok(i64::MAX)
+    );
     assert!(Duration::from_parts(2, 0)
         .try_truncated_nanoseconds()
         .is_ok());


### PR DESCRIPTION
Fixes #475

  ## Background

  The original implementation of `Duration::try_truncated_nanoseconds()` had three related issues:

  1. **Wrong error variant for positive overflow** (the bug #475 describes): `centuries >= 3` returned `Underflow` instead of `Overflow`.
  2. **Aggressive boundary check**: `centuries.abs() >= 3` (and the initial fix's `centuries <= -3`) rejected durations that actually fit within `i64`. For
  example, `Duration::from_truncated_nanoseconds(i64::MIN)` produces `centuries == -3, nanoseconds ≈ 2.4e17` whose total is exactly `i64::MIN` and should
  round-trip cleanly.
  3. **Off-by-NPC formula** in the deeply-negative branch: `(centuries + 1) * NPC + nanoseconds` did not match the canonical `centuries * NPC + nanoseconds`
  from `total_nanoseconds()`.

  This PR initially scoped only (1). On review, @ChristopherRabotin recommended adopting the simpler approach proposed by `gemini-code-assist`, which fixes
  all three at once.

  ## Fix

  Rewrite `try_truncated_nanoseconds` using `total_nanoseconds()` (which returns `i128`) and compare directly against `i64::MIN` / `i64::MAX`:

  ```rust
  pub fn try_truncated_nanoseconds(&self) -> Result<i64, HifitimeError> {
      let total = self.total_nanoseconds();
      if total > i64::MAX as i128 {
          Err(HifitimeError::Duration { source: DurationError::Overflow })
      } else if total < i64::MIN as i128 {
          Err(HifitimeError::Duration { source: DurationError::Underflow })
      } else {
          Ok(total as i64)
      }
  }
  ```

  This is correct by construction: it delegates the value computation to `total_nanoseconds()` (the canonical source of truth) and validates against the
  target type's bounds. No special cases, no intermediate overflow risk (`i128` headroom), no asymmetric edge handling.

  ## Kani harness simplification

  With the implementation now correct for all `i64` inputs, `formal_duration_truncated_ns_reciprocity` collapses to a single round-trip identity assertion:

  ```rust
  #[kani::proof]
  fn formal_duration_truncated_ns_reciprocity() {
      let nanoseconds: i64 = kani::any();
      let dur_from_part = Duration::from_truncated_nanoseconds(nanoseconds);
      let recip_ns = dur_from_part.try_truncated_nanoseconds().unwrap();
      assert_eq!(recip_ns, nanoseconds);
  }
  ```

  The previous version had 5 branches mirroring the buggy implementation's formulas; it was effectively asserting "the function does what the (buggy)
  function does." The new harness asserts the strongest possible property: round-trip identity for every `i64`.

  ## Tests

  `regression_test_gh_475` in `tests/duration.rs` now covers seven cases:

  - `from_parts(3, 0)` → `Overflow` (original regression case)
  - `from_parts(i16::MAX, 0)` → `Overflow` (positive extreme)
  - `from_parts(-3, 0)` → `Underflow` (symmetric boundary)
  - `from_parts(i16::MIN, 0)` → `Underflow` (guards against `.abs()` reintroduction)
  - `from_parts(2, 0)` → `Ok(_)` (sanity: valid range was not narrowed)
  - `from_truncated_nanoseconds(i64::MIN).try_truncated_nanoseconds()` → `Ok(i64::MIN)` (round-trip at negative extreme, the case `gemini-code-assist`
  flagged)
  - `from_truncated_nanoseconds(i64::MAX).try_truncated_nanoseconds()` → `Ok(i64::MAX)` (round-trip at positive extreme)

  ## Verification

  - `cargo fmt --all -- --check`: passing
  - `cargo clippy -- -D warnings`: passing
  - `cargo test`: 166 tests passing (default features)
  - `cargo test --no-default-features`: passing (no-std build)