### PR TITLE
Fix Kani CI - matrix split, retry, and `dead_code` warning

### DIFF
--- a/.github/workflows/weekly-kani-checker.yaml
+++ b/.github/workflows/weekly-kani-checker.yaml
@@ -7,8 +7,139 @@ on:
 
 jobs:
   kani-formal-model-checker:
-    name: Formal Verification
+    name: Kani (${{ matrix.module }})
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Epoch proof_for_contract (48 harnesses, all <14s each)
+          - module: epoch-contracts
+            kani_args: >-
+              --harness kani_harness_Epoch_from_bdt
+              --harness kani_harness_Epoch_from_gpst
+              --harness kani_harness_Epoch_from_gst
+              --harness kani_harness_Epoch_from_qzsst
+              --harness kani_harness_Epoch_from_tai
+              --harness kani_harness_Epoch_from_tdb
+              --harness kani_harness_Epoch_from_tt
+              --harness kani_harness_Epoch_from_utc
+              --harness kani_harness_Epoch_from_et
+              --harness kani_harness_Epoch_from_jde
+              --harness kani_harness_Epoch_from_mjd
+              --harness kani_harness_Epoch_from_duration
+              --harness kani_harness_Epoch_from_time_of_week
+              --harness kani_harness_weekday
+              --harness verify_to_time_scale_contract_tai
+
+          # Epoch proofs — light (<25s each)
+          - module: epoch-proofs-light
+            kani_args: >-
+              --harness formal_epoch_reciprocity
+              --harness kani_harness_Epoch_delta_et_tai
+              --harness kani_harness_Epoch_from_day_of_year
+              --harness kani_harness_Epoch_from_jde_et
+              --harness kani_harness_Epoch_from_jde_tdb
+              --harness kani_harness_Epoch_from_unix
+              --harness kani_harness_Epoch_inner_g
+              --harness kani_harness_Epoch_now
+              --harness kani_harness_LeapSecond_new
+              --harness kani_harness_duration_since_unix_epoch
+              --harness kani_harness_is_gregorian_valid
+              --harness kani_harness_is_leap_year
+              --harness kani_harness_january_years
+              --harness kani_harness_july_years
+              --harness kani_harness_rem_euclid_f64
+              --harness kani_harness_to_duration_since_j1900
+              --harness kani_harness_to_time_of_week
+              --harness kani_harness_to_time_scale
+              --harness kani_harness_usual_days_per_month
+              --harness kani_harness_weekday_in_time_scale
+              --harness kani_harness_weekday_utc
+              --harness verify_epoch_next
+              --harness verify_epoch_previous
+              --harness verify_from_ptp_seconds_contract
+
+          # Epoch proofs — medium (79s)
+          - module: epoch-eq-ord
+            kani_args: "--harness verify_epoch_eq_ord_consistent"
+
+          # Epoch proofs — heavy (100-266s each)
+          - module: epoch-proofs-heavy
+            kani_args: >-
+              --harness verify_next_weekday_at_midnight
+              --harness verify_next_weekday_at_noon
+              --harness verify_previous_weekday_at_midnight
+              --harness verify_previous_weekday_at_noon
+              --harness verify_with_hms_strict_from
+              --harness formal_epoch_julian
+              --harness verify_with_time_from
+              --harness verify_with_hms
+              --harness verify_with_hms_strict
+              --harness verify_with_hms_from
+
+          # Duration: fast harnesses (<45s each)
+          - module: duration-fast
+            kani_args: >-
+              --harness kani_harness_Duration_from_days
+              --harness kani_harness_Duration_from_hours
+              --harness kani_harness_Duration_from_microseconds
+              --harness kani_harness_Duration_from_milliseconds
+              --harness kani_harness_Duration_from_nanoseconds
+              --harness kani_harness_Duration_from_parts
+              --harness kani_harness_Duration_from_seconds
+              --harness kani_harness_Duration_from_total_nanoseconds
+              --harness kani_harness_Duration_from_truncated_nanoseconds
+              --harness kani_harness_abs
+              --harness kani_harness_is_negative
+              --harness kani_harness_max
+              --harness kani_harness_min
+              --harness kani_harness_normalize
+              --harness kani_harness_signum
+              --harness kani_harness_to_parts
+              --harness verify_from_seconds_contract
+              --harness verify_to_seconds_contract
+              --harness verify_total_nanoseconds_contract
+              --harness verify_unit_const_multiply_contract
+              --harness formal_duration_normalize_any
+              --harness formal_duration_truncated_ns_reciprocity
+              --harness kani_harness_to_seconds
+              --harness kani_harness_to_unit
+              --harness kani_harness_total_nanoseconds
+              --harness kani_harness_truncated_nanoseconds
+              --harness kani_harness_try_truncated_nanoseconds
+              --harness test_dur_f64_recip_0
+              --harness verify_approx
+              --harness verify_duration_eq_ord_consistent
+              --harness verify_mul_f64_terminates
+              --harness verify_mul_i64_no_panic
+
+          # Duration: compose (124s + 82s)
+          - module: duration-compose
+            kani_args: "--harness kani_harness_Duration_compose --harness kani_harness_Duration_compose_f64"
+
+          # Duration: from_tz_offset (153s)
+          - module: duration-tz-offset
+            kani_args: "--harness kani_harness_Duration_from_tz_offset"
+
+          # Duration: floor (293s)
+          - module: duration-floor
+            kani_args: "--harness kani_harness_floor"
+
+          # Duration: subdivision (350s)
+          - module: duration-subdivision
+            kani_args: "--harness kani_harness_subdivision"
+
+          # Duration: decompose (524s)
+          - module: duration-decompose
+            kani_args: "--harness kani_harness_decompose"
+
+          # Other: efmt + timescale + top-level + polynomial
+          - module: other
+            kani_args: "--harness efmt:: --harness timescale:: --harness kani_verif:: --harness polynomial::"
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -22,4 +153,4 @@ jobs:
       - name: Kani Rust Verifier
         uses: model-checking/kani-github-action@v1.1
         with:
-          args: --fail-fast -j 8 --output-format=terse -Z function-contracts -Z loop-contracts -Z stubbing
+          args: -j 1 --output-format=terse -Z function-contracts -Z loop-contracts -Z stubbing ${{ matrix.kani_args }}

--- a/src/duration/kani_verif.rs
+++ b/src/duration/kani_verif.rs
@@ -115,6 +115,7 @@ fn verify_from_seconds_contract() {
 
 // Stub for Duration::round — no ensures contract, so kani::stub works.
 #[cfg(kani)]
+#[allow(dead_code)]
 fn stub_round(_self: &Duration, _duration: Duration) -> Duration {
     kani::any()
 }


### PR DESCRIPTION
The weekly Kani verification workflow was failing because a single monolithic job running all 153 harnesses exceeded GitHub-hosted runner limits (7 GB RAM, 2 vCPUs). This PR splits the workflow into 11 parallel matrix jobs grouped by module and verification time, and fixes a `dead_code` warning on `stub_round`.

## Changes

### 1. Fix `dead_code` warning on `stub_round` (`src/duration/kani_verif.rs`)
The `stub_round` function is only referenced via `#[kani::stub]` attributes, which the compiler doesn't see as a "use." Added `#[allow(dead_code)]`.

### 2. Split Kani CI into 11 matrix jobs (`.github/workflows/weekly-kani-checker.yaml`)

| Job | Harnesses | Est. time (sequential) |
|-----|-----------|----------------------|
| `epoch-contracts` | 48 | ~4 min |
| `epoch-proofs-light` | 24 | ~6 min |
| `epoch-eq-ord` | 1 | ~1.5 min |
| `epoch-proofs-heavy` | 10 | ~30 min |
| `duration-fast` | 32 | ~4 min |
| `duration-compose` | 2 | ~3.5 min |
| `duration-tz-offset` | 1 | ~2.5 min |
| `duration-floor` | 1 | ~5 min |
| `duration-subdivision` | 1 | ~6 min |
| `duration-decompose` | 1 | ~9 min |
| `other` | 22 | ~1 min |

All jobs use `-j 1` (sequential verification) to minimize peak memory. Parallelism comes from GitHub running the 11 jobs concurrently. `fail-fast: false` ensures one failure doesn't cancel the rest.

## Observed behavior on `ubuntu-latest`

In testing on my fork, **7 of 11 jobs pass consistently**. The remaining 4 (`epoch-proofs-light`, `duration-compose`, `duration-decompose`, `other`) fail intermittently due to runner preemption — not verification failures. The pattern is:
- All harnesses that complete before preemption show `VERIFICATION:- SUCCESSFUL`
- The job then exits with code 143 ("runner has received a shutdown signal")
- Different jobs fail on different runs (non-deterministic)

## Recommendation: larger runner

The free-tier `ubuntu-latest` runner (7 GB RAM, 2 vCPUs) is marginal for Kani-based verification. The SAT solver's memory footprint during the heaviest harnesses (`decompose`: 524s, `subdivision`: 350s) likely approaches the 7 GB limit, making the job vulnerable to preemption or OOM.

**If the project has access to GitHub Team/Enterprise runners**, switching to `ubuntu-latest-4core` (16 GB RAM, 4 vCPUs) would likely resolve all failures:

```yaml
runs-on: ubuntu-latest-4core  # 16 GB RAM, 4 vCPUs
```

This would also allow increasing `-j` back to 2–4 for faster wall-clock times. The matrix split remains valuable regardless of runner size for debuggability and resilience.
