### PR TITLE
Make `Epoch::to_unix_duration` public for external use

### DIFF
--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -821,7 +821,7 @@ impl Epoch {
     #[must_use]
     /// Returns the Duration since the UNIX epoch UTC midnight 01 Jan 1970.
     /// :rtype: Duration
-    fn to_unix_duration(&self) -> Duration {
+    pub fn to_unix_duration(&self) -> Duration {
         self.to_duration_in_time_scale(TimeScale::UTC) - UNIX_REF_EPOCH.to_utc_duration()
     }
 


### PR DESCRIPTION
This PR makes `Epoch::to_unix_duration` public, matching the already public `Epoch::from_unix_duration`.