### PR TITLE
Handle %w parsing and weekday-only formatting instead of panicking

### DIFF
--- a/src/efmt/format.rs
+++ b/src/efmt/format.rs
@@ -135,12 +135,15 @@ impl Format {
                     | Token::Second
                     | Token::Subsecond
                     | Token::OffsetHours
-                    | Token::OffsetMinutes => return true,
+                    | Token::OffsetMinutes
+                    // The Weekday name tokens need the Gregorian date so the reduced
+                    // (non-Gregorian) formatting branch does not have to handle them;
+                    // that branch only implements WeekdayDecimal.
+                    | Token::Weekday
+                    | Token::WeekdayShort => return true,
                     Token::Timescale
                     | Token::DayOfYearInteger
                     | Token::DayOfYear
-                    | Token::Weekday
-                    | Token::WeekdayShort
                     | Token::WeekdayDecimal => {
                         // These tokens don't need the gregorian, but other tokens in the list of tokens might.
                     }
@@ -305,7 +308,24 @@ impl Format {
                         }
                     }
                     Token::WeekdayDecimal => {
-                        todo!()
+                        // C89 weekday decimal: Sunday=0 .. Saturday=6. Parse it the
+                        // same way as the other numeric tokens (value_ok rejects
+                        // anything outside 0..=6), then invert to_c89_weekday to
+                        // recover the internal Monday=0 .. Sunday=6 ordering. Setting
+                        // `weekday` lets the mismatch check below validate it against
+                        // the parsed date, mirroring the `%A`/`%a` name tokens.
+                        match lexical_core::parse::<i32>(sub_str.as_bytes()) {
+                            Ok(val) => {
+                                prev_token.value_ok(val)?;
+                                weekday = Some(Weekday::from(val as i8 - 1));
+                            }
+                            Err(err) => {
+                                return Err(HifitimeError::Parse {
+                                    source: ParsingError::Lexical { err },
+                                    details: "could not parse weekday decimal",
+                                });
+                            }
+                        }
                     }
                     Token::MonthName | Token::MonthNameShort => {
                         match MonthName::from_str(sub_str) {

--- a/tests/efmt.rs
+++ b/tests/efmt.rs
@@ -240,3 +240,102 @@ fn regression_test_gh_246() {
         })
     );
 }
+
+// Regression tests for the two efmt weekday-token panics reachable from the safe
+// public API in released 4.3.0:
+//   * `%w` (WeekdayDecimal) parsing hit `todo!()` in Format::parse.
+//   * weekday-only `%A`/`%a` formatting hit `unreachable!()` in Formatter.
+// 2026-07-26 (Sunday) .. 2026-08-01 (Saturday) give one epoch per C89 weekday
+// value (Sunday=0 .. Saturday=6).
+
+#[test]
+fn weekday_only_format_does_not_panic() {
+    use core::str::FromStr;
+    let e = Epoch::from_gregorian_utc_at_midnight(2026, 7, 29); // Wednesday
+
+    // `%A`/`%a` alone previously reached `unreachable!()`.
+    assert_eq!(
+        Formatter::new(e, Format::from_str("%A").unwrap()).to_string(),
+        "Wednesday"
+    );
+    assert_eq!(
+        Formatter::new(e, Format::from_str("%a").unwrap()).to_string(),
+        "Wed"
+    );
+    // `%w` alone already formatted; keep it as a control.
+    assert_eq!(
+        Formatter::new(e, Format::from_str("%w").unwrap()).to_string(),
+        "3"
+    );
+}
+
+#[test]
+fn weekday_decimal_parse_roundtrips() {
+    // `%w` parsing previously reached `todo!()`.
+    let wednesday = Epoch::from_gregorian_utc_at_midnight(2026, 7, 29);
+    assert_eq!(
+        Epoch::from_format_str("3 2026-07-29", "%w %Y-%m-%d").unwrap(),
+        wednesday
+    );
+
+    // Self-consistency: the formatter emits the `%w` value the parser reads back.
+    use core::str::FromStr;
+    let fmt = "%w %Y-%m-%d";
+    let formatted = Formatter::new(wednesday, Format::from_str(fmt).unwrap()).to_string();
+    assert_eq!(formatted, "3 2026-07-29");
+    assert_eq!(Epoch::from_format_str(&formatted, fmt).unwrap(), wednesday);
+}
+
+#[test]
+fn weekday_decimal_maps_every_c89_value() {
+    // Exhaustive inverse of Weekday::to_c89_weekday over a full week.
+    let week = [
+        (26, 0, Weekday::Sunday),
+        (27, 1, Weekday::Monday),
+        (28, 2, Weekday::Tuesday),
+        (29, 3, Weekday::Wednesday),
+        (30, 4, Weekday::Thursday),
+        (31, 5, Weekday::Friday),
+    ];
+    for (day, c89, wd) in week {
+        let s = format!("{c89} 2026-07-{day:02}");
+        let e = Epoch::from_format_str(&s, "%w %Y-%m-%d").unwrap();
+        assert_eq!(e.weekday(), wd, "%w={c89} should be {wd:?}");
+        assert_eq!(e, Epoch::from_gregorian_utc_at_midnight(2026, 7, day));
+    }
+    // Saturday (%w == 6) rolls into August.
+    let e = Epoch::from_format_str("6 2026-08-01", "%w %Y-%m-%d").unwrap();
+    assert_eq!(e.weekday(), Weekday::Saturday);
+}
+
+#[test]
+fn weekday_decimal_parse_validates_against_date() {
+    // 2026-07-29 is a Wednesday (%w == 3). Supplying 5 (Friday) must be rejected
+    // with WeekdayMismatch, exactly like the `%A`/`%a` name tokens already are.
+    assert_eq!(
+        Epoch::from_format_str("5 2026-07-29", "%w %Y-%m-%d"),
+        Err(HifitimeError::Parse {
+            source: ParsingError::WeekdayMismatch {
+                found: Weekday::Friday,
+                expected: Weekday::Wednesday,
+            },
+            details: "weekday and day number do not match",
+        })
+    );
+}
+
+#[test]
+fn weekday_decimal_parse_rejects_out_of_range() {
+    // The C89 weekday decimal is 0..=6; 7 must be a value error, not a silent wrap.
+    let err = Epoch::from_format_str("7 2026-07-29", "%w %Y-%m-%d").unwrap_err();
+    assert!(
+        matches!(
+            err,
+            HifitimeError::Parse {
+                source: ParsingError::ValueError,
+                ..
+            }
+        ),
+        "expected a ValueError, got {err:?}"
+    );
+}


### PR DESCRIPTION
The `efmt` strftime module has two code paths that panic on valid, in-domain input reachable from the safe public API (both shipped in 4.3.0):

**1. Parsing `%w` panics with `todo!()`** (`src/efmt/format.rs`, `Format::parse`):

```rust
let e = Epoch::from_format_str("3 2026-07-29", "%w %Y-%m-%d");
// thread panicked: not yet implemented
```

**2. Formatting a weekday-only format panics with `unreachable!()`** (`src/efmt/formatter.rs`):

```rust
let e = Epoch::from_gregorian_utc_at_midnight(2026, 7, 29);
let _ = Formatter::new(e, Format::from_str("%A").unwrap()).to_string();
// thread panicked: internal error: entered unreachable code
```

Both share one theme: the weekday tokens were only partially wired up. `%A`/`%a` format fine when combined with a Gregorian token (e.g. `%A %Y-%m-%d`) because `need_gregorian()` then routes through the branch that implements them, but on their own they fall into the reduced branch's `_ => unreachable!()`. And the formatter emits a `%w` value that `parse` could not read back, so a `%w` round-trip crashed.

Fixes:

- `%w` parsing now mirrors the existing numeric-token arm: parse the decimal, run the already-present `WeekdayDecimal` `value_ok` range check (0..=6, previously unreachable), and invert `to_c89_weekday` (C89 `Sunday=0..Saturday=6`) back to the internal `Monday=0..Sunday=6` ordering. The parsed weekday feeds the existing consistency check, so a `%w` that contradicts the date is rejected with `WeekdayMismatch`, exactly like the `%A`/`%a` name tokens. It validates rather than silently accepts.
- `need_gregorian()` now returns true for `Weekday`/`WeekdayShort`, routing weekday-only formats through the branch that already handles them. Any format affected by this previously hit the `unreachable!()`, so there is no prior working behaviour to change.

I audited the rest of `efmt` for the same shape: these are the only two panic sites reachable from valid public input. The remaining `todo!()`/`unreachable!()` arms in `format.rs` are dead (those tokens are consumed by explicit arms earlier in the match), so I left them untouched to keep the diff minimal.

Tests added to `tests/efmt.rs` cover the full inverse map over a week, `%w` format round-trips, the date-mismatch rejection, and out-of-range rejection. Verified `cargo test`, `--no-default-features`, and `--features serde` all pass, plus `cargo fmt`. The change is confined to `efmt`, which is not under the Kani proofs, so no proof is affected.
