### PR TITLE
Fix Duration subtraction saturation at bounds

### DIFF
--- a/src/duration/ops.rs
+++ b/src/duration/ops.rs
@@ -302,35 +302,7 @@ impl Sub for Duration {
         // Ensure that the durations are normalized to avoid extra logic to handle under/overflows
         self.normalize();
         rhs.normalize();
-        match self.centuries.checked_sub(rhs.centuries) {
-            None => {
-                // Underflowed, so we've hit the min
-                return Self::MIN;
-            }
-            Some(centuries) => {
-                self.centuries = centuries;
-            }
-        }
-
-        match self.nanoseconds.checked_sub(rhs.nanoseconds) {
-            None => {
-                // Decrease the number of centuries, and realign
-                match self.centuries.checked_sub(1) {
-                    Some(centuries) => {
-                        self.centuries = centuries;
-                        self.nanoseconds += NANOSECONDS_PER_CENTURY - rhs.nanoseconds;
-                    }
-                    None => {
-                        // We're at the min number of centuries already, and we have extra nanos, so we're saturated the duration limit
-                        return Self::MIN;
-                    }
-                };
-            }
-            Some(nanos) => self.nanoseconds = nanos,
-        };
-
-        self.normalize();
-        self
+        Self::from_total_nanoseconds(self.total_nanoseconds() - rhs.total_nanoseconds())
     }
 }
 

--- a/src/duration/ops.rs
+++ b/src/duration/ops.rs
@@ -302,7 +302,35 @@ impl Sub for Duration {
         // Ensure that the durations are normalized to avoid extra logic to handle under/overflows
         self.normalize();
         rhs.normalize();
-        Self::from_total_nanoseconds(self.total_nanoseconds() - rhs.total_nanoseconds())
+
+        // Widen the century subtraction so that its direction is still known
+        // when the result exceeds the Duration bounds.
+        let mut centuries = i32::from(self.centuries) - i32::from(rhs.centuries);
+        let mut nanoseconds = match self.nanoseconds.checked_sub(rhs.nanoseconds) {
+            Some(nanoseconds) => nanoseconds,
+            None => {
+                centuries -= 1;
+                NANOSECONDS_PER_CENTURY - (rhs.nanoseconds - self.nanoseconds)
+            }
+        };
+
+        // MAX is the only normalized value whose nanoseconds equal a full
+        // century. Carry it before checking the widened century bounds.
+        if nanoseconds == NANOSECONDS_PER_CENTURY {
+            centuries += 1;
+            nanoseconds = 0;
+        }
+
+        if centuries > i32::from(i16::MAX) {
+            Self::MAX
+        } else if centuries < i32::from(i16::MIN) {
+            Self::MIN
+        } else {
+            Self {
+                centuries: centuries as i16,
+                nanoseconds,
+            }
+        }
     }
 }
 

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -237,6 +237,23 @@ fn test_ops_near_bounds() {
     assert_ne!(Duration::MAX - 1 * Unit::Nanosecond, Duration::MAX);
 }
 
+/// Regression test for https://github.com/nyx-space/hifitime/issues/494
+#[test]
+fn test_subtraction_saturates_in_the_result_direction() {
+    assert_eq!(Duration::ZERO - Duration::MIN, Duration::MAX);
+    assert_eq!(Duration::MAX - Duration::MIN, Duration::MAX);
+    assert_eq!(Duration::ZERO - Duration::MAX, Duration::MIN);
+    assert_eq!(Duration::MIN - Duration::MAX, Duration::MIN);
+    assert_eq!(
+        Duration::ZERO - (Duration::MIN + Duration::EPSILON),
+        Duration::MAX - Duration::EPSILON
+    );
+    assert_eq!(
+        Duration::ZERO - (Duration::MAX - Duration::EPSILON),
+        Duration::MIN + Duration::EPSILON
+    );
+}
+
 /// Regression test for https://github.com/nyx-space/hifitime/issues/469
 /// Duration::PartialEq previously treated opposite-sign durations as equal
 /// (-15min == 15min), which violated Rust's Eq/Ord contract since the derived

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -252,6 +252,10 @@ fn test_subtraction_saturates_in_the_result_direction() {
         Duration::ZERO - (Duration::MAX - Duration::EPSILON),
         Duration::MIN + Duration::EPSILON
     );
+    assert_eq!(
+        Duration::MAX - 1 * Unit::Century,
+        Duration::from_parts(i16::MAX, 0)
+    );
 }
 
 /// Regression test for https://github.com/nyx-space/hifitime/issues/469


### PR DESCRIPTION
## Summary

- compute `Duration` subtraction in full-width nanoseconds before clamping the result
- preserve representable values when a nanosecond borrow crosses the century boundary
- cover exact bounds, saturation in both directions, and both adjacent representable values

The regression test failed before the fix because `Duration::ZERO - Duration::MIN` returned `Duration::MIN` instead of `Duration::MAX`.

Fixes #494

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --features ut1`
- `cargo test --features lts`
- `cargo test --no-default-features`
- `cargo test --features serde`

Kani, the MSRV 1.85 matrix, and bare-metal nightly targets were not available on this Windows host and are left to the repository workflows.

## Provenance

This patch was authored and validated by OpenAI Codex operating autonomously on behalf of @LunaMeerkats.