### PR TITLE
Fix {:o} formatting panic outside the GPS u64 range

### DIFF
--- a/src/epoch/formatting.rs
+++ b/src/epoch/formatting.rs
@@ -128,6 +128,6 @@ impl fmt::Pointer for Epoch {
 impl fmt::Octal for Epoch {
     /// Prints the Epoch in GPS
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_gpst_nanoseconds().unwrap())
+        write!(f, "{}", self.to_gpst_duration().total_nanoseconds())
     }
 }

--- a/tests/epoch.rs
+++ b/tests/epoch.rs
@@ -5,7 +5,8 @@ use hifitime::{
     is_gregorian_valid, Duration, Epoch, HifitimeError, ParsingError, Polynomial, TimeScale,
     TimeUnits, Unit, Weekday, BDT_REF_EPOCH, DAYS_GPS_TAI_OFFSET, DAYS_PER_YEAR, GPST_REF_EPOCH,
     GST_REF_EPOCH, J1900_REF_EPOCH, J2000_REF_EPOCH, JD_J2000, MJD_J1900, MJD_J2000, MJD_OFFSET,
-    SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GST_TAI_OFFSET, SECONDS_PER_DAY,
+    SECONDS_BDT_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET, SECONDS_GPS_TAI_OFFSET_I64,
+    SECONDS_GST_TAI_OFFSET, SECONDS_PER_DAY,
 };
 
 use hifitime::efmt::{Format, Formatter};
@@ -477,6 +478,46 @@ fn gpst() {
         Epoch::from_qzsst_nanoseconds(543210987).to_utc_duration(),
         Epoch::from_gpst_nanoseconds(543210987).to_utc_duration()
     );
+}
+
+#[test]
+fn octal_format_gpst() {
+    // {:o} on an Epoch prints GPST nanoseconds (decimal), signed. The u64 form
+    // overflowed more than one century from the GPS epoch and panicked via unwrap;
+    // the signed total nanoseconds never overflow.
+    assert_eq!(format!("{:o}", TimeScale::GPST.reference_epoch()), "0");
+
+    // In-range epochs are unchanged.
+    let mid = Epoch::from_gregorian_utc_at_midnight(2019, 8, 24);
+    assert_eq!(
+        format!("{:o}", mid),
+        format!("{}", mid.to_gpst_nanoseconds().unwrap())
+    );
+
+    // Pre-1980 (the UNIX epoch): negative GPST offset, no panic.
+    let unix = Epoch::from_gregorian_utc_at_midnight(1970, 1, 1);
+    let expected = unix.to_tai_duration().total_nanoseconds()
+        - SECONDS_GPS_TAI_OFFSET_I64 as i128 * 1_000_000_000;
+    assert!(expected < 0);
+    assert_eq!(format!("{:o}", unix), format!("{}", expected));
+
+    // One day either side of the GPS epoch.
+    assert_eq!(
+        format!("{:o}", Epoch::from_gregorian_utc_at_midnight(1980, 1, 5)),
+        "-86400000000000"
+    );
+    assert_eq!(
+        format!("{:o}", Epoch::from_gregorian_utc_at_midnight(1980, 1, 7)),
+        "86400000000000"
+    );
+
+    // Post-2080: to_gpst_nanoseconds errors (more than one century past the GPS
+    // epoch); the octal format no longer panics and prints the signed total.
+    let far = Epoch::from_gregorian_utc_at_midnight(2100, 1, 1);
+    assert!(far.to_gpst_nanoseconds().is_err());
+    let far_expected = far.to_tai_duration().total_nanoseconds()
+        - SECONDS_GPS_TAI_OFFSET_I64 as i128 * 1_000_000_000;
+    assert_eq!(format!("{:o}", far), format!("{}", far_expected));
 }
 
 #[test]

--- a/tests/timeseries.rs
+++ b/tests/timeseries.rs
@@ -1,6 +1,6 @@
 extern crate hifitime;
 
-use hifitime::{Epoch, TimeSeries, TimeUnits, Unit};
+use hifitime::{Duration, Epoch, TimeSeries, TimeUnits, Unit};
 
 #[test]
 fn test_timeseries() {
@@ -91,6 +91,19 @@ fn test_timeseries() {
     }
 
     assert_eq!(count, 7, "Should have six items in this iterator");
+}
+
+#[test]
+fn octal_format_pre_gps() {
+    // {:o} on a TimeSeries formats both bound epochs in GPS nanoseconds; a series
+    // starting before the GPS epoch (1980-01-06) used to panic.
+    let start = Epoch::from_gregorian_utc_at_midnight(1970, 1, 1);
+    let end = Epoch::from_gregorian_utc_at_midnight(1971, 1, 1);
+    let series = TimeSeries::inclusive(start, end, Duration::from_days(1.0));
+    assert_eq!(
+        format!("{series:o}"),
+        "TimeSeries [-315964819000000000 : -284428819000000000 : 1 day]"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`{:o}` on an Epoch panics for any instant outside the u64 GPST-nanosecond window (before 1980-01-06 or after ~2080): `to_gpst_nanoseconds()` returns an overflow error there and the Octal impl unwraps it. Formatting 1970-01-01 UTC, the UNIX epoch, panics. Our earlier #495 fixed the two panic sites in `efmt`; this one is outside `efmt`, in the `fmt::Octal` impl (formatting.rs:131), which that audit missed.

The fix formats the signed total GPS nanoseconds (`Duration::total_nanoseconds()`, which never overflows) instead of the fallible u64. In-range output is unchanged (the other format traits in this file use the letter as a time-scale access key — `{:x}` is TAI, `{:p}` is unix — so the decimal GPST-nanosecond output stands). Pre-1980 epochs now print the negative offset (1970-01-01 -> `-315964819000000000`), and post-2080 epochs no longer panic. TimeSeries `{:o}` is covered as well, since it formats both bounds through the Epoch impl.

Added boundary tests either side of the GPS epoch and a TimeSeries regression; `cargo test` on all CI feature variants, clippy, and fmt are clean.