### PR TITLE
Switch latest leap seconds to static instead of const

### DIFF
--- a/benches/crit_epoch.rs
+++ b/benches/crit_epoch.rs
@@ -16,6 +16,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("UTC to ET", |b| {
+        b.iter(|| {
+            let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);
+            black_box(e.to_time_scale(hifitime::TimeScale::ET));
+        })
+    });
+
     c.bench_function("TT", |b| {
         b.iter(|| {
             let e = Epoch::from_gregorian_utc_hms(2015, 2, 7, 11, 22, 33);

--- a/src/epoch/leap_seconds.rs
+++ b/src/epoch/leap_seconds.rs
@@ -44,7 +44,7 @@ impl LeapSecond {
         }
     }
 }
-
+#[cfg(not(kani))]
 static LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
     LeapSecond::new(1_893_369_600.0, 1.417818, false), // SOFA: 01 Jan 1960
     LeapSecond::new(1_924_992_000.0, 1.422818, false), // SOFA: 01 Jan 1961
@@ -93,8 +93,8 @@ static LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
 /// List of leap seconds from <https://data.iana.org/time-zones/data/leap-seconds.list>.
 /// This list corresponds the number of seconds in TAI to the UTC offset and to whether it was an announced leap second or not.
 /// The unannoucned leap seconds come from dat.c in the SOFA library.
+#[cfg(not(kani))]
 #[cfg_attr(feature = "python", pyclass)]
-#[cfg_attr(kani, derive(kani::Arbitrary))]
 #[derive(Clone, Debug)]
 pub struct LatestLeapSeconds {
     data: &'static [LeapSecond; 42],
@@ -149,10 +149,77 @@ impl LatestLeapSeconds {
     }
 }
 
+#[cfg(not(kani))]
 impl Default for LatestLeapSeconds {
     fn default() -> Self {
         Self {
             data: &LATEST_LEAP_SECONDS,
+            iter_pos: 0,
+        }
+    }
+}
+
+// Kani uses the old const approach which does not have lifetime issues when deriving Arbitrary.
+
+#[cfg(kani)]
+const LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
+    LeapSecond::new(1_893_369_600.0, 1.417818, false), // SOFA: 01 Jan 1960
+    LeapSecond::new(1_924_992_000.0, 1.422818, false), // SOFA: 01 Jan 1961
+    LeapSecond::new(1_943_308_800.0, 1.372818, false), // SOFA: 01 Aug 1961
+    LeapSecond::new(1_956_528_000.0, 1.845858, false), // SOFA: 01 Jan 1962
+    LeapSecond::new(2_014_329_600.0, 1.945858, false), // SOFA: 01 Jan 1963
+    LeapSecond::new(2_019_600_000.0, 3.24013, false),  // SOFA: 01 Jan 1964
+    LeapSecond::new(2_027_462_400.0, 3.34013, false),  // SOFA: 01 Apr 1964
+    LeapSecond::new(2_040_681_600.0, 3.44013, false),  // SOFA: 01 Sep 1964
+    LeapSecond::new(2_051_222_400.0, 3.54013, false),  // SOFA: 01 Jan 1965
+    LeapSecond::new(2_056_320_000.0, 3.64013, false),  // SOFA: 01 Mar 1965
+    LeapSecond::new(2_066_860_800.0, 3.74013, false),  // SOFA: 01 Jul 1965
+    LeapSecond::new(2_072_217_600.0, 3.84013, false),  // SOFA: 01 Sep 1965
+    LeapSecond::new(2_082_758_400.0, 4.31317, false),  // SOFA: 01 Jan 1966
+    LeapSecond::new(2_148_508_800.0, 4.21317, false),  // SOFA: 01 Feb 1968
+    LeapSecond::new(2_272_060_800.0, 10.0, true),      // IERS: 01 Jan 1972
+    LeapSecond::new(2_287_785_600.0, 11.0, true),      // IERS: 01 Jul 1972
+    LeapSecond::new(2_303_683_200.0, 12.0, true),      // IERS: 01 Jan 1973
+    LeapSecond::new(2_335_219_200.0, 13.0, true),      // IERS: 01 Jan 1974
+    LeapSecond::new(2_366_755_200.0, 14.0, true),      // IERS: 01 Jan 1975
+    LeapSecond::new(2_398_291_200.0, 15.0, true),      // IERS: 01 Jan 1976
+    LeapSecond::new(2_429_913_600.0, 16.0, true),      // IERS: 01 Jan 1977
+    LeapSecond::new(2_461_449_600.0, 17.0, true),      // IERS: 01 Jan 1978
+    LeapSecond::new(2_492_985_600.0, 18.0, true),      // IERS: 01 Jan 1979
+    LeapSecond::new(2_524_521_600.0, 19.0, true),      // IERS: 01 Jan 1980
+    LeapSecond::new(2_571_782_400.0, 20.0, true),      // IERS: 01 Jul 1981
+    LeapSecond::new(2_603_318_400.0, 21.0, true),      // IERS: 01 Jul 1982
+    LeapSecond::new(2_634_854_400.0, 22.0, true),      // IERS: 01 Jul 1983
+    LeapSecond::new(2_698_012_800.0, 23.0, true),      // IERS: 01 Jul 1985
+    LeapSecond::new(2_776_982_400.0, 24.0, true),      // IERS: 01 Jan 1988
+    LeapSecond::new(2_840_140_800.0, 25.0, true),      // IERS: 01 Jan 1990
+    LeapSecond::new(2_871_676_800.0, 26.0, true),      // IERS: 01 Jan 1991
+    LeapSecond::new(2_918_937_600.0, 27.0, true),      // IERS: 01 Jul 1992
+    LeapSecond::new(2_950_473_600.0, 28.0, true),      // IERS: 01 Jul 1993
+    LeapSecond::new(2_982_009_600.0, 29.0, true),      // IERS: 01 Jul 1994
+    LeapSecond::new(3_029_443_200.0, 30.0, true),      // IERS: 01 Jan 1996
+    LeapSecond::new(3_076_704_000.0, 31.0, true),      // IERS: 01 Jul 1997
+    LeapSecond::new(3_124_137_600.0, 32.0, true),      // IERS: 01 Jan 1999
+    LeapSecond::new(3_345_062_400.0, 33.0, true),      // IERS: 01 Jan 2006
+    LeapSecond::new(3_439_756_800.0, 34.0, true),      // IERS: 01 Jan 2009
+    LeapSecond::new(3_550_089_600.0, 35.0, true),      // IERS: 01 Jul 2012
+    LeapSecond::new(3_644_697_600.0, 36.0, true),      // IERS: 01 Jul 2015
+    LeapSecond::new(3_692_217_600.0, 37.0, true),      // IERS: 01 Jan 2017
+];
+
+#[cfg(kani)]
+#[cfg_attr(feature = "python", pyclass)]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
+#[derive(Clone, Debug)]
+pub struct LatestLeapSeconds {
+    data: [LeapSecond; 42],
+    iter_pos: usize,
+}
+#[cfg(kani)]
+impl Default for LatestLeapSeconds {
+    fn default() -> Self {
+        Self {
+            data: LATEST_LEAP_SECONDS,
             iter_pos: 0,
         }
     }

--- a/src/epoch/leap_seconds.rs
+++ b/src/epoch/leap_seconds.rs
@@ -44,7 +44,7 @@ impl LeapSecond {
         }
     }
 }
-#[cfg(not(kani))]
+
 static LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
     LeapSecond::new(1_893_369_600.0, 1.417818, false), // SOFA: 01 Jan 1960
     LeapSecond::new(1_924_992_000.0, 1.422818, false), // SOFA: 01 Jan 1961
@@ -93,7 +93,6 @@ static LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
 /// List of leap seconds from <https://data.iana.org/time-zones/data/leap-seconds.list>.
 /// This list corresponds the number of seconds in TAI to the UTC offset and to whether it was an announced leap second or not.
 /// The unannoucned leap seconds come from dat.c in the SOFA library.
-#[cfg(not(kani))]
 #[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Debug)]
 pub struct LatestLeapSeconds {
@@ -149,77 +148,10 @@ impl LatestLeapSeconds {
     }
 }
 
-#[cfg(not(kani))]
 impl Default for LatestLeapSeconds {
     fn default() -> Self {
         Self {
             data: &LATEST_LEAP_SECONDS,
-            iter_pos: 0,
-        }
-    }
-}
-
-// Kani uses the old const approach which does not have lifetime issues when deriving Arbitrary.
-
-#[cfg(kani)]
-const LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
-    LeapSecond::new(1_893_369_600.0, 1.417818, false), // SOFA: 01 Jan 1960
-    LeapSecond::new(1_924_992_000.0, 1.422818, false), // SOFA: 01 Jan 1961
-    LeapSecond::new(1_943_308_800.0, 1.372818, false), // SOFA: 01 Aug 1961
-    LeapSecond::new(1_956_528_000.0, 1.845858, false), // SOFA: 01 Jan 1962
-    LeapSecond::new(2_014_329_600.0, 1.945858, false), // SOFA: 01 Jan 1963
-    LeapSecond::new(2_019_600_000.0, 3.24013, false),  // SOFA: 01 Jan 1964
-    LeapSecond::new(2_027_462_400.0, 3.34013, false),  // SOFA: 01 Apr 1964
-    LeapSecond::new(2_040_681_600.0, 3.44013, false),  // SOFA: 01 Sep 1964
-    LeapSecond::new(2_051_222_400.0, 3.54013, false),  // SOFA: 01 Jan 1965
-    LeapSecond::new(2_056_320_000.0, 3.64013, false),  // SOFA: 01 Mar 1965
-    LeapSecond::new(2_066_860_800.0, 3.74013, false),  // SOFA: 01 Jul 1965
-    LeapSecond::new(2_072_217_600.0, 3.84013, false),  // SOFA: 01 Sep 1965
-    LeapSecond::new(2_082_758_400.0, 4.31317, false),  // SOFA: 01 Jan 1966
-    LeapSecond::new(2_148_508_800.0, 4.21317, false),  // SOFA: 01 Feb 1968
-    LeapSecond::new(2_272_060_800.0, 10.0, true),      // IERS: 01 Jan 1972
-    LeapSecond::new(2_287_785_600.0, 11.0, true),      // IERS: 01 Jul 1972
-    LeapSecond::new(2_303_683_200.0, 12.0, true),      // IERS: 01 Jan 1973
-    LeapSecond::new(2_335_219_200.0, 13.0, true),      // IERS: 01 Jan 1974
-    LeapSecond::new(2_366_755_200.0, 14.0, true),      // IERS: 01 Jan 1975
-    LeapSecond::new(2_398_291_200.0, 15.0, true),      // IERS: 01 Jan 1976
-    LeapSecond::new(2_429_913_600.0, 16.0, true),      // IERS: 01 Jan 1977
-    LeapSecond::new(2_461_449_600.0, 17.0, true),      // IERS: 01 Jan 1978
-    LeapSecond::new(2_492_985_600.0, 18.0, true),      // IERS: 01 Jan 1979
-    LeapSecond::new(2_524_521_600.0, 19.0, true),      // IERS: 01 Jan 1980
-    LeapSecond::new(2_571_782_400.0, 20.0, true),      // IERS: 01 Jul 1981
-    LeapSecond::new(2_603_318_400.0, 21.0, true),      // IERS: 01 Jul 1982
-    LeapSecond::new(2_634_854_400.0, 22.0, true),      // IERS: 01 Jul 1983
-    LeapSecond::new(2_698_012_800.0, 23.0, true),      // IERS: 01 Jul 1985
-    LeapSecond::new(2_776_982_400.0, 24.0, true),      // IERS: 01 Jan 1988
-    LeapSecond::new(2_840_140_800.0, 25.0, true),      // IERS: 01 Jan 1990
-    LeapSecond::new(2_871_676_800.0, 26.0, true),      // IERS: 01 Jan 1991
-    LeapSecond::new(2_918_937_600.0, 27.0, true),      // IERS: 01 Jul 1992
-    LeapSecond::new(2_950_473_600.0, 28.0, true),      // IERS: 01 Jul 1993
-    LeapSecond::new(2_982_009_600.0, 29.0, true),      // IERS: 01 Jul 1994
-    LeapSecond::new(3_029_443_200.0, 30.0, true),      // IERS: 01 Jan 1996
-    LeapSecond::new(3_076_704_000.0, 31.0, true),      // IERS: 01 Jul 1997
-    LeapSecond::new(3_124_137_600.0, 32.0, true),      // IERS: 01 Jan 1999
-    LeapSecond::new(3_345_062_400.0, 33.0, true),      // IERS: 01 Jan 2006
-    LeapSecond::new(3_439_756_800.0, 34.0, true),      // IERS: 01 Jan 2009
-    LeapSecond::new(3_550_089_600.0, 35.0, true),      // IERS: 01 Jul 2012
-    LeapSecond::new(3_644_697_600.0, 36.0, true),      // IERS: 01 Jul 2015
-    LeapSecond::new(3_692_217_600.0, 37.0, true),      // IERS: 01 Jan 2017
-];
-
-#[cfg(kani)]
-#[cfg_attr(feature = "python", pyclass)]
-#[cfg_attr(kani, derive(kani::Arbitrary))]
-#[derive(Clone, Debug)]
-pub struct LatestLeapSeconds {
-    data: [LeapSecond; 42],
-    iter_pos: usize,
-}
-#[cfg(kani)]
-impl Default for LatestLeapSeconds {
-    fn default() -> Self {
-        Self {
-            data: LATEST_LEAP_SECONDS,
             iter_pos: 0,
         }
     }

--- a/src/epoch/leap_seconds.rs
+++ b/src/epoch/leap_seconds.rs
@@ -45,7 +45,7 @@ impl LeapSecond {
     }
 }
 
-const LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
+static LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
     LeapSecond::new(1_893_369_600.0, 1.417818, false), // SOFA: 01 Jan 1960
     LeapSecond::new(1_924_992_000.0, 1.422818, false), // SOFA: 01 Jan 1961
     LeapSecond::new(1_943_308_800.0, 1.372818, false), // SOFA: 01 Aug 1961
@@ -97,7 +97,7 @@ const LATEST_LEAP_SECONDS: [LeapSecond; 42] = [
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[derive(Clone, Debug)]
 pub struct LatestLeapSeconds {
-    data: [LeapSecond; 42],
+    data: &'static [LeapSecond; 42],
     iter_pos: usize,
 }
 
@@ -152,7 +152,7 @@ impl LatestLeapSeconds {
 impl Default for LatestLeapSeconds {
     fn default() -> Self {
         Self {
-            data: LATEST_LEAP_SECONDS,
+            data: &LATEST_LEAP_SECONDS,
             iter_pos: 0,
         }
     }


### PR DESCRIPTION
In theory this should lead to a speedup, let's check the benchmarks.

Results: 
- TBD seconds and JDE ET: sped up by 100 ns
- TT: sped up by 50 ns

Added a new benchmark that converts form UTC to ET.

On this branch:

```
UTC to ET               time:   [486.73 ns 492.90 ns 499.95 ns]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
```

On master (after running on this branch):

```
TBD seconds and JDE ET  time:   [1.1241 µs 1.1321 µs 1.1416 µs]
                        change: [+1.4889% +2.9622% +4.2750%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

UTC to ET               time:   [488.10 ns 491.21 ns 494.29 ns]
                        change: [+1.3694% +2.2958% +3.3155%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

TT                      time:   [409.03 ns 411.95 ns 415.02 ns]
                        change: [−0.3812% +0.6389% +1.5179%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```